### PR TITLE
Refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,9 @@ jobs:
       - name: Build tests
         run: |
           cmake --preset test_gcc -B build/debug/gcc
-          cd ./build/debug/gcc && ninja
+          cmake --build build/debug/gcc
       - name: Run tests
-        run: |
-          ./build/debug/gcc/test/btree_test
-          ./build/debug/gcc/test/btree_pmr_test
+        run: ctest --test-dir build/debug/gcc --output-on-failure
 
   clang:
     runs-on: ubuntu-latest
@@ -31,11 +29,9 @@ jobs:
       - name: Build tests
         run: |
           cmake --preset test_clang -B build/debug/clang
-          cd ./build/debug/clang && ninja
+          cmake --build build/debug/clang
       - name: Run tests
-        run: |
-          ./build/debug/clang/test/btree_test
-          ./build/debug/clang/test/btree_pmr_test
+        run: ctest --test-dir build/debug/clang --output-on-failure
 
   clang_memory:
     # libstdc++ and libc++ have uninitialized variables,
@@ -51,8 +47,6 @@ jobs:
       - name: Build tests
         run: |
           cmake --preset test_clang_memory -B build/debug/clang/memory
-          cd ./build/debug/clang/memory && ninja
+          cmake --build build/debug/clang/memory
       - name: Run tests
-        run: |
-          ./build/debug/clang/memory/test/btree_test
-          ./build/debug/clang/memory/test/btree_pmr_test
+        run: ctest --test-dir build/debug/clang/memory --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ cmake_minimum_required(VERSION 3.31)
 project(platanus VERSION 1.1.0 LANGUAGES CXX)
 
 option(PLATANUS_BUILD_TESTS "Build B-tree tests" OFF)
+option(PLATANUS_BUILD_BENCHMARK "Build B-tree benchmark" OFF)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_OPTIMIZE_DEPENDENCIES ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.27.7)
+cmake_minimum_required(VERSION 3.31)
 
 project(platanus VERSION 1.1.0 LANGUAGES CXX)
 
@@ -42,7 +42,7 @@ add_library(platanus INTERFACE)
 
 target_compile_features(platanus INTERFACE cxx_std_20)
 target_include_directories(platanus INTERFACE
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/platanus>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
@@ -53,7 +53,7 @@ install(TARGETS platanus
 
 install(
   DIRECTORY
-    ${CMAKE_CURRENT_SOURCE_DIR}/platanus
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/platanus
   DESTINATION
     ${CMAKE_INSTALL_INCLUDEDIR}
 )

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ See [here](https://sukeya.github.io/platanus/).
 
 
 ## License
-`platanus` is licensed under [Apache License, Version 2.0](COPYING).
+`platanus` is licensed under [Apache License, Version 2.0](LICENSE).

--- a/docs/reference/btree_map.md
+++ b/docs/reference/btree_map.md
@@ -7,8 +7,8 @@ template <
     typename Key,
     typename Value,
     typename Compare           = std::ranges::less,
-    typename Alloc             = std::allocator<Key>,
-    std::int_least16_t MaxNumOfValues = 512>
+    typename Alloc             = std::allocator<std::pair<const Key, Value>>,
+    int MaxNumOfValues         = 64>
 class btree_map;
 }
 ```
@@ -21,7 +21,7 @@ class btree_map;
 | `Key` | Type of a key |
 | `Value` | Type of a value |
 | `Compare` | Type of a func obj comparing two key in a weak order. If Key doesn't implement three-way comparison operator, the default type does using `<` and `=`. |
-| `Alloc` | Type of an allocator. The default is `std::allocator<Key>`. |
+| `Alloc` | Type of an allocator. The default is `std::allocator<std::pair<const Key, Value>>`. |
 | `MaxNumOfValues` | The max number of values per node. The default is 64. |
 
 

--- a/docs/reference/btree_multimap.md
+++ b/docs/reference/btree_multimap.md
@@ -7,8 +7,8 @@ template <
     typename Key,
     typename Value,
     typename Compare           = std::ranges::less,
-    typename Alloc             = std::allocator<Key>,
-    std::int_least16_t MaxNumOfValues = 512>
+    typename Alloc             = std::allocator<std::pair<const Key, Value>>,
+    int MaxNumOfValues         = 64>
 class btree_multimap;
 }
 ```
@@ -21,7 +21,7 @@ class btree_multimap;
 | `Key` | Type of a key |
 | `Value` | Type of a value |
 | `Compare` | Type of a func obj comparing two key in a weak order. If Key doesn't implement three-way comparison operator, the default type does using `<` and `=`. |
-| `Alloc` | Type of an allocator. The default is `std::allocator<Key>`. |
+| `Alloc` | Type of an allocator. The default is `std::allocator<std::pair<const Key, Value>>`. |
 | `MaxNumOfValues` | The max number of values per node. The default is 64. |
 
 

--- a/docs/reference/btree_multiset.md
+++ b/docs/reference/btree_multiset.md
@@ -30,7 +30,6 @@ class btree_multiset;
 | key_type | Type of key, i.e. `Key` |
 | value_type | Type of value, i.e. `Key` |
 | key_compare | Type of comparer of key, i.e. `Compare` |
-| value_compare | Type of comparer of value, i.e. `Compare` |
 | allocator_type | Type of allocator, i.e. `Alloc` |
 | pointer | Type of pointer to value, i.e. `Key*` |
 | const_pointer | Type of pointer to const value, i.e. `const Key*` |

--- a/docs/reference/btree_multiset.md
+++ b/docs/reference/btree_multiset.md
@@ -7,7 +7,7 @@ template <
     typename Key,
     typename Compare           = std::ranges::less,
     typename Alloc             = std::allocator<Key>,
-    std::int_least16_t MaxNumOfValues = 512>
+    int MaxNumOfValues         = 64>
 class btree_multiset;
 }
 ```

--- a/docs/reference/btree_set.md
+++ b/docs/reference/btree_set.md
@@ -30,7 +30,6 @@ class btree_set;
 | key_type | Type of key, i.e. `Key` |
 | value_type | Type of value, i.e. `Key` |
 | key_compare | Type of comparer of key, i.e. `Compare` |
-| value_compare | Type of comparer of value, i.e. `Compare` |
 | allocator_type | Type of allocator, i.e. `Alloc` |
 | pointer | Type of pointer to value, i.e. `Key*` |
 | const_pointer | Type of pointer to const value, i.e. `const Key*` |

--- a/docs/reference/btree_set.md
+++ b/docs/reference/btree_set.md
@@ -7,7 +7,7 @@ template <
     typename Key,
     typename Compare           = std::ranges::less,
     typename Alloc             = std::allocator<Key>,
-    std::int_least16_t MaxNumOfValues = 512>
+    int MaxNumOfValues         = 64>
 class btree_set;
 }
 ```

--- a/include/platanus/btree_map.hpp
+++ b/include/platanus/btree_map.hpp
@@ -60,7 +60,6 @@ class btree_map
   using value_type             = typename super_type::value_type;
   using mapped_type            = typename super_type::mapped_type;
   using key_compare            = typename super_type::key_compare;
-  using value_compare          = typename super_type::value_compare;
   using allocator_type         = typename super_type::allocator_type;
   using pointer                = typename super_type::pointer;
   using const_pointer          = typename super_type::const_pointer;
@@ -189,7 +188,6 @@ class btree_multimap
   using key_type               = typename super_type::key_type;
   using value_type             = typename super_type::value_type;
   using key_compare            = typename super_type::key_compare;
-  using value_compare          = typename super_type::value_compare;
   using allocator_type         = typename super_type::allocator_type;
   using pointer                = typename super_type::pointer;
   using const_pointer          = typename super_type::const_pointer;
@@ -323,7 +321,6 @@ class btree_map : public internal::btree_map_container<
   using value_type             = typename super_type::value_type;
   using mapped_type            = typename super_type::mapped_type;
   using key_compare            = typename super_type::key_compare;
-  using value_compare          = typename super_type::value_compare;
   using allocator_type         = typename super_type::allocator_type;
   using pointer                = typename super_type::pointer;
   using const_pointer          = typename super_type::const_pointer;
@@ -459,7 +456,6 @@ class btree_multimap
   using key_type               = typename super_type::key_type;
   using value_type             = typename super_type::value_type;
   using key_compare            = typename super_type::key_compare;
-  using value_compare          = typename super_type::value_compare;
   using allocator_type         = typename super_type::allocator_type;
   using pointer                = typename super_type::pointer;
   using const_pointer          = typename super_type::const_pointer;

--- a/include/platanus/btree_map.hpp
+++ b/include/platanus/btree_map.hpp
@@ -126,10 +126,10 @@ class btree_map
   using super_type::rbegin;
   using super_type::rend;
 
-  using super_type::capacity;
   using super_type::empty;
   using super_type::max_size;
   using super_type::size;
+  using super_type::theoretical_max_size;
 
   using super_type::clear;
   using super_type::dump;
@@ -256,10 +256,10 @@ class btree_multimap
   using super_type::rbegin;
   using super_type::rend;
 
-  using super_type::capacity;
   using super_type::empty;
   using super_type::max_size;
   using super_type::size;
+  using super_type::theoretical_max_size;
 
   using super_type::clear;
   using super_type::dump;
@@ -389,10 +389,10 @@ class btree_map : public internal::btree_map_container<
   using super_type::rbegin;
   using super_type::rend;
 
-  using super_type::capacity;
   using super_type::empty;
   using super_type::max_size;
   using super_type::size;
+  using super_type::theoretical_max_size;
 
   using super_type::clear;
   using super_type::dump;
@@ -526,10 +526,10 @@ class btree_multimap
   using super_type::rbegin;
   using super_type::rend;
 
-  using super_type::capacity;
   using super_type::empty;
   using super_type::max_size;
   using super_type::size;
+  using super_type::theoretical_max_size;
 
   using super_type::clear;
   using super_type::dump;

--- a/include/platanus/btree_set.hpp
+++ b/include/platanus/btree_set.hpp
@@ -127,10 +127,10 @@ class btree_set
   using super_type::rbegin;
   using super_type::rend;
 
-  using super_type::capacity;
   using super_type::empty;
   using super_type::max_size;
   using super_type::size;
+  using super_type::theoretical_max_size;
 
   using super_type::clear;
   using super_type::dump;
@@ -252,10 +252,10 @@ class btree_multiset
   using super_type::rbegin;
   using super_type::rend;
 
-  using super_type::capacity;
   using super_type::empty;
   using super_type::max_size;
   using super_type::size;
+  using super_type::theoretical_max_size;
 
   using super_type::clear;
   using super_type::dump;
@@ -376,10 +376,10 @@ class btree_set
   using super_type::rbegin;
   using super_type::rend;
 
-  using super_type::capacity;
   using super_type::empty;
   using super_type::max_size;
   using super_type::size;
+  using super_type::theoretical_max_size;
 
   using super_type::clear;
   using super_type::dump;
@@ -498,10 +498,10 @@ class btree_multiset
   using super_type::rbegin;
   using super_type::rend;
 
-  using super_type::capacity;
   using super_type::empty;
   using super_type::max_size;
   using super_type::size;
+  using super_type::theoretical_max_size;
 
   using super_type::clear;
   using super_type::dump;

--- a/include/platanus/btree_set.hpp
+++ b/include/platanus/btree_set.hpp
@@ -60,7 +60,6 @@ class btree_set
   using key_type               = typename super_type::key_type;
   using value_type             = typename super_type::value_type;
   using key_compare            = typename super_type::key_compare;
-  using value_compare          = typename super_type::value_compare;
   using allocator_type         = typename super_type::allocator_type;
   using pointer                = typename super_type::pointer;
   using const_pointer          = typename super_type::const_pointer;
@@ -185,7 +184,6 @@ class btree_multiset
   using key_type               = typename super_type::key_type;
   using value_type             = typename super_type::value_type;
   using key_compare            = typename super_type::key_compare;
-  using value_compare          = typename super_type::value_compare;
   using allocator_type         = typename super_type::allocator_type;
   using pointer                = typename super_type::pointer;
   using const_pointer          = typename super_type::const_pointer;
@@ -309,7 +307,6 @@ class btree_set
   using key_type               = typename super_type::key_type;
   using value_type             = typename super_type::value_type;
   using key_compare            = typename super_type::key_compare;
-  using value_compare          = typename super_type::value_compare;
   using allocator_type         = typename super_type::allocator_type;
   using pointer                = typename super_type::pointer;
   using const_pointer          = typename super_type::const_pointer;
@@ -431,7 +428,6 @@ class btree_multiset
   using key_type               = typename super_type::key_type;
   using value_type             = typename super_type::value_type;
   using key_compare            = typename super_type::key_compare;
-  using value_compare          = typename super_type::value_compare;
   using allocator_type         = typename super_type::allocator_type;
   using pointer                = typename super_type::pointer;
   using const_pointer          = typename super_type::const_pointer;

--- a/include/platanus/internal/btree.hpp
+++ b/include/platanus/internal/btree.hpp
@@ -330,7 +330,7 @@ class btree {
     return size() == 0;
   }
 
-  size_type capacity() const noexcept { return nodes() * kNodeValues; }
+  size_type theoretical_max_size() const noexcept { return nodes() * kNodeValues; }
 
   // The height of the btree. An empty tree will have height 0.
   size_type height() const noexcept;

--- a/include/platanus/internal/btree.hpp
+++ b/include/platanus/internal/btree.hpp
@@ -111,7 +111,7 @@ class btree {
 
   explicit btree(const key_compare& comp, const allocator_type& alloc);
 
-  explicit btree(const btree& x, const allocator_type& alloc) : btree(key_compare{}, alloc) {
+  explicit btree(const btree& x, const allocator_type& alloc) : btree(x.key_comp(), alloc) {
     copy(x);
   }
 

--- a/include/platanus/internal/btree.hpp
+++ b/include/platanus/internal/btree.hpp
@@ -498,13 +498,7 @@ class btree {
 /////////////////////////////////////////////////////////////////////////
 // btree implementation
 template <class NF>
-btree<NF>::btree(const btree& x)
-    : comp_(x.comp_),
-      node_factory_(x.node_factory_),
-      root_(),
-      rightmost_(x.rightmost_),
-      leftmost_(x.leftmost_),
-      size_(x.size_) {
+btree<NF>::btree(const btree& x) : comp_(x.comp_), node_factory_(x.node_factory_) {
   copy(x);
 }
 

--- a/include/platanus/internal/btree.hpp
+++ b/include/platanus/internal/btree.hpp
@@ -83,7 +83,6 @@ class btree {
   using mapped_type            = typename params_type::mapped_type;
   using value_type             = typename params_type::value_type;
   using key_compare            = typename params_type::key_compare;
-  using value_compare          = typename params_type::value_compare;
   using pointer                = typename params_type::pointer;
   using const_pointer          = typename params_type::const_pointer;
   using reference              = typename params_type::reference;

--- a/include/platanus/internal/btree.hpp
+++ b/include/platanus/internal/btree.hpp
@@ -34,12 +34,10 @@
 #include <cstddef>
 #include <cstring>
 #include <initializer_list>
-#include <iostream>
 #include <iterator>
 #include <limits>
 #include <ostream>
 #include <ranges>
-#include <sys/types.h>
 #include <stdexcept>
 #include <utility>
 

--- a/include/platanus/internal/btree.hpp
+++ b/include/platanus/internal/btree.hpp
@@ -1113,87 +1113,42 @@ void btree<NF>::merge_unique(self_type& rhd) {
     return;
   }
 
-  auto lhd_min = params_type::key(*(begin()));
-  auto lhd_max = params_type::key(*(rbegin()));
-  auto rhd_min = params_type::key(*(rhd.begin()));
-  auto rhd_max = params_type::key(*(rhd.rbegin()));
-
-  const auto& comp = ref_key_comp();
-
+  // Ensure *this has the smaller minimum key.
   {
-    bool is_greater = false;
+    const auto& lhd_first          = params_type::key(*begin());
+    const auto& rhd_first          = params_type::key(*rhd.begin());
+    bool        lhd_min_is_smaller = false;
     if constexpr (comp_return_weak_ordering<key_type, key_compare>) {
-      is_greater = (comp(lhd_min, rhd_min) < 0);
+      lhd_min_is_smaller = (ref_key_comp()(lhd_first, rhd_first) < 0);
     } else {
-      is_greater = comp(lhd_min, rhd_min);
+      lhd_min_is_smaller = ref_key_comp()(lhd_first, rhd_first);
     }
-    // If lhd_min >= rhd_min,
-    if (not is_greater) {
+    if (!lhd_min_is_smaller) {
       swap(rhd);
     }
   }
 
-  // If the value range of rhd is included in that of *this,
-  {
-    bool is_greater = false;
-    if constexpr (comp_return_weak_ordering<key_type, key_compare>) {
-      is_greater = (comp(lhd_max, rhd_max) < 0);
+  // Capture lhd_max after any swap (by value; a reference can be invalidated by insert).
+  const auto lhd_max = params_type::key(*rbegin());
+
+  auto it = rhd.begin();
+
+  // Phase 1: intersection range (key <= lhd_max) — check for duplicates.
+  // insert_unique moves *it only when the key is unique; on duplicate it returns without moving.
+  while (it != rhd.end() && !compare_keys(lhd_max, params_type::key(*it))) {
+    auto [_, is_inserted] = insert_unique(std::move(*it));
+    if (is_inserted) {
+      it = rhd.erase(it);  // erase moved-from element, receive next valid iterator
     } else {
-      is_greater = comp(lhd_max, rhd_max);
-    }
-    // If rhd_max <= lhd_max
-    if (not is_greater) {
-      // Store the keys removed from rhd temporarily.
-      std::vector<std::ptrdiff_t> removed_indexes;
-
-      // Insert the intersection to *this.
-      for (std::ptrdiff_t i = 0; auto& v : rhd) {
-        auto [_, is_inserted] = insert_unique(std::move(v));
-        if (is_inserted) {
-          removed_indexes.push_back(i);
-        }
-        ++i;
-      }
-
-      // Remove the keys inserted to *this.
-      for (auto i : removed_indexes | std::views::reverse) {
-        rhd.erase(std::next(rhd.begin(), i));
-      }
-
-      return;
+      ++it;  // duplicate: value was not moved, stays in rhd
     }
   }
 
-  // Store the keys removed from rhd temporarily.
-  std::vector<std::ptrdiff_t> removed_indexes;
-
-  auto rhd_intersection_end = rhd.upper_bound(lhd_max);
-
-  // Insert the intersection to *this.
-  {
-    for (std::ptrdiff_t i = 0; auto& v : std::ranges::subrange{rhd.begin(), rhd_intersection_end}) {
-      auto [_, is_inserted] = insert_unique(std::move(v));
-      if (is_inserted) {
-        removed_indexes.push_back(i);
-      }
-      ++i;
-    }
-    // Insert the extra of rhd.
-    for (auto& v : std::ranges::subrange{rhd_intersection_end, rhd.end()}) {
-      insert_unique(end(), std::move(v));
-    }
-  }
-
-  // Remove the extra of rhd.
-  // Using `erase`, the former iterators are made to be invalidated.
-  // So, I use classical for loop.
-  std::ptrdiff_t num_value_out_of_left = std::distance(rhd_intersection_end, rhd.end());
-  for (std::ptrdiff_t i = 0; i < num_value_out_of_left; ++i) {
-    rhd.erase(std::prev(rhd.end()));
-  }
-  // Remove the keys inserted to *this.
-  for (auto i : removed_indexes | std::views::reverse) {
-    rhd.erase(std::next(rhd.begin(), i));
+  // Phase 2: extra range (key > lhd_max) — no duplicates possible.
+  // Use end() hint for O(1) amortized insert.
+  while (it != rhd.end()) {
+    insert_unique(end(), std::move(*it));
+    it = rhd.erase(it);
   }
 }
 

--- a/include/platanus/internal/btree_base_node.hpp
+++ b/include/platanus/internal/btree_base_node.hpp
@@ -59,7 +59,6 @@ class btree_base_node {
   using reference          = typename Params::reference;
   using const_reference    = typename Params::const_reference;
   using key_compare        = typename Params::key_compare;
-  using value_compare      = typename Params::value_compare;
   using size_type          = typename Params::size_type;
   using difference_type    = typename Params::difference_type;
 

--- a/include/platanus/internal/btree_container.hpp
+++ b/include/platanus/internal/btree_container.hpp
@@ -104,7 +104,7 @@ class btree_container {
   size_type size() const noexcept { return tree_.size(); }
   size_type max_size() const noexcept { return tree_.max_size(); }
   bool      empty() const noexcept { return tree_.empty(); }
-  size_type capacity() const noexcept { return tree_.capacity(); }
+  size_type theoretical_max_size() const noexcept { return tree_.theoretical_max_size(); }
   size_type height() const noexcept { return tree_.height(); }
   size_type internal_nodes() const noexcept { return tree_.internal_nodes(); }
   size_type leaf_nodes() const noexcept { return tree_.leaf_nodes(); }

--- a/include/platanus/internal/btree_container.hpp
+++ b/include/platanus/internal/btree_container.hpp
@@ -48,7 +48,6 @@ class btree_container {
   using key_type               = typename Tree::key_type;
   using value_type             = typename Tree::value_type;
   using key_compare            = typename Tree::key_compare;
-  using value_compare          = typename Tree::value_compare;
   using allocator_type         = typename Tree::allocator_type;
   using pointer                = typename Tree::pointer;
   using const_pointer          = typename Tree::const_pointer;
@@ -153,7 +152,6 @@ class btree_unique_container : public btree_container<Tree> {
   using key_type               = typename super_type::key_type;
   using value_type             = typename super_type::value_type;
   using key_compare            = typename super_type::key_compare;
-  using value_compare          = typename super_type::value_compare;
   using allocator_type         = typename super_type::allocator_type;
   using pointer                = typename super_type::pointer;
   using const_pointer          = typename super_type::const_pointer;
@@ -306,7 +304,6 @@ class btree_map_container : public btree_unique_container<Tree> {
   using key_type               = typename super_type::key_type;
   using value_type             = typename super_type::value_type;
   using key_compare            = typename super_type::key_compare;
-  using value_compare          = typename super_type::value_compare;
   using allocator_type         = typename super_type::allocator_type;
   using pointer                = typename super_type::pointer;
   using const_pointer          = typename super_type::const_pointer;
@@ -438,7 +435,6 @@ class btree_multi_container : public btree_container<Tree> {
   using key_type               = typename super_type::key_type;
   using value_type             = typename super_type::value_type;
   using key_compare            = typename super_type::key_compare;
-  using value_compare          = typename super_type::value_compare;
   using allocator_type         = typename super_type::allocator_type;
   using pointer                = typename super_type::pointer;
   using const_pointer          = typename super_type::const_pointer;

--- a/include/platanus/internal/btree_node.hpp
+++ b/include/platanus/internal/btree_node.hpp
@@ -128,8 +128,11 @@ class btree_node : public btree_base_node<Params, btree_node<Params>> {
 
     void operator()(pointer p) {
       if (p != nullptr) {
-        // FIXME Some children whose index is over children_count() haven't been freed, so I free
-        // all children.
+        // The children array is allocated with kNodeChildren slots, but only [0, count()] are
+        // logically active. After split/merge operations, slots beyond count() may still hold
+        // initialized node_owner objects (i.e. non-null unique_ptrs) that were moved out of but
+        // not yet destroyed. Iterating over all kNodeChildren slots and destroying each non-null
+        // entry ensures those residual owners are also released.
         for (count_type i = 0; i < kNodeChildren; ++i) {
           if (p[i]) {
             children_allocator_traits::destroy(*this, &p[i]);

--- a/include/platanus/internal/btree_node.hpp
+++ b/include/platanus/internal/btree_node.hpp
@@ -58,7 +58,6 @@ class btree_node : public btree_base_node<Params, btree_node<Params>> {
   using reference          = typename super_type::reference;
   using const_reference    = typename super_type::const_reference;
   using key_compare        = typename super_type::key_compare;
-  using value_compare      = typename super_type::value_compare;
   using size_type          = typename super_type::size_type;
   using difference_type    = typename super_type::difference_type;
 

--- a/include/platanus/internal/btree_node.hpp
+++ b/include/platanus/internal/btree_node.hpp
@@ -128,7 +128,8 @@ class btree_node : public btree_base_node<Params, btree_node<Params>> {
 
     void operator()(pointer p) {
       if (p != nullptr) {
-        // FIXME some children whose index is over children_count() haven't been freed.
+        // FIXME Some children whose index is over children_count() haven't been freed, so I free
+        // all children.
         for (count_type i = 0; i < kNodeChildren; ++i) {
           if (p[i]) {
             children_allocator_traits::destroy(*this, &p[i]);

--- a/include/platanus/internal/btree_param.hpp
+++ b/include/platanus/internal/btree_param.hpp
@@ -41,8 +41,7 @@ namespace platanus::internal {
 template <typename Key, typename Compare, typename Alloc, int MaxNumOfValues>
 requires comp_requirement<Key, Compare>
 struct btree_common_params {
-  using key_compare   = Compare;
-  using value_compare = std::false_type;
+  using key_compare = Compare;
 
   using allocator_type  = Alloc;
   using key_type        = Key;
@@ -63,8 +62,6 @@ struct btree_map_params : public btree_common_params<Key, Compare, Alloc, MaxNum
 
   using key_compare =
       typename btree_common_params<Key, Compare, Alloc, MaxNumOfValues>::key_compare;
-  // TODO implement value_compare
-  using value_compare   = std::false_type;
   using pointer         = value_type*;
   using const_pointer   = const value_type*;
   using reference       = value_type&;
@@ -83,7 +80,6 @@ struct btree_set_params : public btree_common_params<Key, Compare, Alloc, MaxNum
 
   using key_compare =
       typename btree_common_params<Key, Compare, Alloc, MaxNumOfValues>::key_compare;
-  using value_compare   = key_compare;
   using pointer         = value_type*;
   using const_pointer   = const value_type*;
   using reference       = value_type&;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ function(add_btree_test target)
       $<${is_gcc}:-Wtrampolines>
   )
   target_link_libraries(${target} GTest::gtest_main platanus util)
+  add_test(NAME ${target} COMMAND ${target})
 endfunction()
 
 add_btree_test(btree_test)


### PR DESCRIPTION
This PR improves consistency across the public API, build/test workflow, and reference documentation in platanus. It also includes a few internal cleanups to make the library behavior more predictable, especially around stateful comparators and CI-based verification.

- Fix CMake install settings so exported headers and package configuration match the actual include layout
- Switch GitHub Actions test execution to ctest so CI follows the same test entrypoint as local CMake-based workflows
- Simplify the public API by removing value_compare and renaming capacity to theoretical_max_size
- Preserve stateful comparators in allocator-aware copy construction
- Update the reference documentation for btree_set / btree_map families so template defaults and exposed types match the implementation