### PR TITLE
benchmark: add Abseil comparison mode and refresh docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ project(platanus VERSION 1.1.0 LANGUAGES CXX)
 option(PLATANUS_BUILD_TESTS "Build B-tree tests" OFF)
 option(PLATANUS_BUILD_BENCHMARK "Build B-tree benchmark" OFF)
 option(PLATANUS_BENCHMARK_VALUES_SIZE_TEST "Test values sizes of B-tree" OFF)
+option(PLATANUS_BENCHMARK_WITH_ABSL "Build benchmark in STL/Abseil/platanus(64) comparison mode" ON)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_OPTIMIZE_DEPENDENCIES ON)
@@ -118,6 +119,17 @@ if(PLATANUS_BUILD_BENCHMARK)
     OVERRIDE_FIND_PACKAGE
   )
   FetchContent_MakeAvailable(benchmark)
+
+  if(PLATANUS_BENCHMARK_WITH_ABSL)
+    set(ABSL_PROPAGATE_CXX_STD ON)
+    set(ABSL_BUILD_TESTING OFF)
+    FetchContent_Declare(
+      abseil-cpp
+      URL      https://github.com/abseil/abseil-cpp/releases/download/20260107.1/abseil-cpp-20260107.1.tar.gz
+      OVERRIDE_FIND_PACKAGE
+    )
+    FetchContent_MakeAvailable(abseil-cpp)
+  endif()
 
   add_subdirectory(util)
   add_subdirectory(benchmark)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ project(platanus VERSION 1.1.0 LANGUAGES CXX)
 
 option(PLATANUS_BUILD_TESTS "Build B-tree tests" OFF)
 option(PLATANUS_BUILD_BENCHMARK "Build B-tree benchmark" OFF)
+option(PLATANUS_BENCHMARK_VALUES_SIZE_TEST "Test values sizes of B-tree" OFF)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_OPTIMIZE_DEPENDENCIES ON)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -62,14 +62,16 @@
       "inherits": ["benchmark"],
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "g++",
-        "CMAKE_CXX_FLAGS": "-O2 -DNDEBUG"
+        "CMAKE_CXX_FLAGS": "-O2 -DNDEBUG",
+        "PLATANUS_BENCHMARK_WITH_ABSL" : "ON"
       }
     },
     {
       "name": "benchmark_clang",
       "inherits": ["benchmark", "clang"],
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-stdlib=libc++ -O2 -DNDEBUG"
+        "CMAKE_CXX_FLAGS": "-stdlib=libc++ -O2 -DNDEBUG",
+        "PLATANUS_BENCHMARK_WITH_ABSL" : "ON"
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,23 @@
 ## Documentation
 See [here](https://sukeya.github.io/platanus/).
 
+## Benchmark
+You can build the benchmark with:
+
+```bash
+cmake -S . -B build/release -DPLATANUS_BUILD_BENCHMARK=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build/release --target btree_bench
+```
+
+When `PLATANUS_BENCHMARK_WITH_ABSL=ON` (default), the benchmark runs in comparison mode and registers:
+
+- `STL`
+- `absl`
+- `platanus(64)`
+
+In that mode, `platanus(128)` and `platanus::pmr` benchmark variants are intentionally excluded.
+See the documentation site for more benchmark details and plotting scripts.
+
 
 ## License
 `platanus` is licensed under [Apache License, Version 2.0](LICENSE).

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -28,6 +28,10 @@
 
 add_executable(btree_bench btree_bench.cpp)
 target_link_libraries(btree_bench platanus util benchmark::benchmark)
+if (PLATANUS_BENCHMARK_WITH_ABSL)
+  target_link_libraries(btree_bench absl::btree)
+  target_compile_definitions(btree_bench PRIVATE PLATANUS_BENCHMARK_WITH_ABSL)
+endif()
 if (PLATANUS_BENCHMARK_VALUES_SIZE_TEST)
   target_compile_definitions(btree_bench PRIVATE PLATANUS_BENCHMARK_VALUES_SIZE_TEST)
 endif()

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -28,6 +28,6 @@
 
 add_executable(btree_bench btree_bench.cpp)
 target_link_libraries(btree_bench platanus util benchmark::benchmark)
-if (PLATANUS_VALUES_SIZE_TEST)
-  target_compile_definitions(btree_bench PRIVATE PLATANUS_VALUES_SIZE_TEST)
+if (PLATANUS_BENCHMARK_VALUES_SIZE_TEST)
+  target_compile_definitions(btree_bench PRIVATE PLATANUS_BENCHMARK_VALUES_SIZE_TEST)
 endif()

--- a/benchmark/btree_bench.cpp
+++ b/benchmark/btree_bench.cpp
@@ -264,7 +264,7 @@ using STLMap = std::map<T, T>;
 template <class T>
 using STLMultiMap = std::multimap<T, T>;
 
-#ifdef PLATANUS_VALUES_SIZE_TEST
+#ifdef PLATANUS_BENCHMARK_VALUES_SIZE_TEST
 #define BTREE_BENCHMARK(tree, type, func) \
   BENCHMARK(BM_##func<tree<type, 3>>);    \
   BENCHMARK(BM_##func<tree<type, 8>>);    \

--- a/benchmark/btree_bench.cpp
+++ b/benchmark/btree_bench.cpp
@@ -38,6 +38,8 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/btree_map.h"
+#include "absl/container/btree_set.h"
 #include "benchmark/benchmark.h"
 
 #include "platanus/btree_map.hpp"
@@ -264,6 +266,18 @@ using STLMap = std::map<T, T>;
 template <class T>
 using STLMultiMap = std::multimap<T, T>;
 
+template <class T>
+using AbslSet = absl::btree_set<T, std::less<T>>;
+
+template <class T>
+using AbslMultiSet = absl::btree_multiset<T, std::less<T>>;
+
+template <class T>
+using AbslMap = absl::btree_map<T, T, std::less<T>>;
+
+template <class T>
+using AbslMultiMap = absl::btree_multimap<T, T, std::less<T>>;
+
 #ifdef PLATANUS_BENCHMARK_VALUES_SIZE_TEST
 #define BTREE_BENCHMARK(tree, type, func) \
   BENCHMARK(BM_##func<tree<type, 3>>);    \
@@ -279,17 +293,35 @@ using STLMultiMap = std::multimap<T, T>;
   BENCHMARK(BM_##func<tree<type, 128>>);
 #endif
 
+#define BTREE_64_BENCHMARK(tree, type, func) BENCHMARK(BM_##func<tree<type, 64>>);
+
+#define ABSL_BENCHMARK(container, type, func) BENCHMARK(BM_##func<Absl##container<type>>);
+
 #define STL_AND_BTREE_BENCHMARK(container, type, func) \
   BENCHMARK(BM_##func<STL##container<type>>);          \
   BTREE_BENCHMARK(BTree##container, type, func);       \
   BTREE_BENCHMARK(BTreePmr##container, type, func);
 
+#define STL_ABSL_AND_BTREE64_BENCHMARK(container, type, func) \
+  BENCHMARK(BM_##func<STL##container<type>>);                 \
+  ABSL_BENCHMARK(container, type, func);                      \
+  BTREE_64_BENCHMARK(BTree##container, type, func);
+
+#ifdef PLATANUS_BENCHMARK_WITH_ABSL
+#define REGISTER_BENCHMARK_FUNCTIONS(container, type)       \
+  STL_ABSL_AND_BTREE64_BENCHMARK(container, type, Insert);  \
+  STL_ABSL_AND_BTREE64_BENCHMARK(container, type, Lookup);  \
+  STL_ABSL_AND_BTREE64_BENCHMARK(container, type, Delete);  \
+  STL_ABSL_AND_BTREE64_BENCHMARK(container, type, FwdIter); \
+  STL_ABSL_AND_BTREE64_BENCHMARK(container, type, Merge);
+#else
 #define REGISTER_BENCHMARK_FUNCTIONS(container, type) \
   STL_AND_BTREE_BENCHMARK(container, type, Insert);   \
   STL_AND_BTREE_BENCHMARK(container, type, Lookup);   \
   STL_AND_BTREE_BENCHMARK(container, type, Delete);   \
   STL_AND_BTREE_BENCHMARK(container, type, FwdIter);  \
   STL_AND_BTREE_BENCHMARK(container, type, Merge);
+#endif
 
 #define REGISTER_BENCHMARK_TYPES(container)              \
   REGISTER_BENCHMARK_FUNCTIONS(container, std::int32_t); \

--- a/benchmark/btree_bench.cpp
+++ b/benchmark/btree_bench.cpp
@@ -51,19 +51,6 @@ static_assert(sizeof(std::size_t) == 8, "must fix the bits of mersenne twister e
 // The size of values used in each benchmark.
 static constexpr std::int64_t values_size = 1'000'000;
 
-struct StringComp {
-  std::weak_ordering operator()(const std::string& lhd, const std::string& rhd) const noexcept {
-    auto result = lhd.compare(rhd);
-    if (result < 0) {
-      return std::weak_ordering::less;
-    } else if (result > 0) {
-      return std::weak_ordering::greater;
-    } else {
-      return std::weak_ordering::equivalent;
-    }
-  }
-};
-
 // Benchmark insertion of values into a container.
 template <typename T>
 static void BM_Insert(benchmark::State& state) {
@@ -181,25 +168,11 @@ struct SetCompAndAllocToSet {
 };
 
 template <
-    template <class, class, class, std::int_least16_t> class BTreeContainer,
-    std::int_least16_t N>
-struct SetCompAndAllocToSet<BTreeContainer, std::string, N> {
-  using type = BTreeContainer<std::string, StringComp, std::allocator<std::string>, N>;
-};
-
-template <
     template <class, class, class, class, std::int_least16_t> class BTreeContainer,
     class T,
     std::int_least16_t N>
 struct SetCompAndAllocToMap {
   using type = BTreeContainer<T, T, std::ranges::less, std::allocator<T>, N>;
-};
-
-template <
-    template <class, class, class, class, std::int_least16_t> class BTreeContainer,
-    std::int_least16_t N>
-struct SetCompAndAllocToMap<BTreeContainer, std::string, N> {
-  using type = BTreeContainer<std::string, std::string, StringComp, std::allocator<std::string>, N>;
 };
 
 template <
@@ -210,24 +183,12 @@ struct SetCompToPmrSet {
   using type = BTreeContainer<T, std::ranges::less, N>;
 };
 
-template <template <class, class, std::int_least16_t> class BTreeContainer, std::int_least16_t N>
-struct SetCompToPmrSet<BTreeContainer, std::string, N> {
-  using type = BTreeContainer<std::string, StringComp, N>;
-};
-
 template <
     template <class, class, class, std::int_least16_t> class BTreeContainer,
     class T,
     std::int_least16_t N>
 struct SetCompToPmrMap {
   using type = BTreeContainer<T, T, std::ranges::less, N>;
-};
-
-template <
-    template <class, class, class, std::int_least16_t> class BTreeContainer,
-    std::int_least16_t N>
-struct SetCompToPmrMap<BTreeContainer, std::string, N> {
-  using type = BTreeContainer<std::string, std::string, StringComp, N>;
 };
 
 template <class T, std::int_least16_t N>
@@ -293,7 +254,8 @@ using AbslMultiMap = absl::btree_multimap<T, T, std::less<T>>;
   BENCHMARK(BM_##func<tree<type, 128>>);
 #endif
 
-#define BTREE_64_BENCHMARK(tree, type, func) BENCHMARK(BM_##func<tree<type, 64>>);
+#define BTREE_AUTOSIZE_BENCHMARK(tree, type, func) \
+  BENCHMARK(BM_##func<tree<type, platanus::kAutoSize>>);
 
 #define ABSL_BENCHMARK(container, type, func) BENCHMARK(BM_##func<Absl##container<type>>);
 
@@ -305,7 +267,7 @@ using AbslMultiMap = absl::btree_multimap<T, T, std::less<T>>;
 #define STL_ABSL_AND_BTREE64_BENCHMARK(container, type, func) \
   BENCHMARK(BM_##func<STL##container<type>>);                 \
   ABSL_BENCHMARK(container, type, func);                      \
-  BTREE_64_BENCHMARK(BTree##container, type, func);
+  BTREE_AUTOSIZE_BENCHMARK(BTree##container, type, func);
 
 #ifdef PLATANUS_BENCHMARK_WITH_ABSL
 #define REGISTER_BENCHMARK_FUNCTIONS(container, type)       \

--- a/benchmark/compare_benchmark_stats.py
+++ b/benchmark/compare_benchmark_stats.py
@@ -41,14 +41,10 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "left",
-        nargs="?",
-        required=True,
         help="First benchmark JSON file.",
     )
     parser.add_argument(
         "right",
-        nargs="?",
-        required=True,
         help="Second benchmark JSON file.",
     )
     parser.add_argument("-o", "--output", default="compared_stats.txt")

--- a/benchmark/compare_benchmarks.py
+++ b/benchmark/compare_benchmarks.py
@@ -46,7 +46,7 @@ def build_order(left: dict[str, float], right: dict[str, float]) -> list[str]:
 
 BENCHMARK_PATTERN = re.compile(
     r"^(?P<benchmark>BM_[^<]+)"
-    r"<(?P<impl>STL|BTree)"
+    r"<(?P<impl>STL|Absl|BTree)"
     r"(?P<container>MultiMap|MultiSet|Map|Set)"
     r"<(?P<data_type>std::(?:int32_t|int64_t|string))"
     r"(?:, (?P<node_size>\d+))?"
@@ -65,6 +65,9 @@ def parse_benchmark_name(name: str) -> dict[str, str] | None:
     if impl == "STL":
         parsed["label"] = "STL"
         return parsed
+    if impl == "Absl":
+        parsed["label"] = "absl"
+        return parsed
     if impl == "BTree" and node_size is not None:
         parsed["label"] = f"platanus({node_size})"
         return parsed
@@ -79,10 +82,12 @@ def subplot_title(benchmark: str, data_type: str, container: str) -> str:
 def implementation_sort_key(label: str) -> tuple[int, int]:
     if label == "STL":
         return (0, 0)
+    if label == "absl":
+        return (1, 0)
     match = re.fullmatch(r"platanus\((\d+)\)", label)
     if match is not None:
-        return (1, int(match.group(1)))
-    return (2, 0)
+        return (2, int(match.group(1)))
+    return (3, 0)
 
 
 IMPLEMENTATION_PALETTE = [

--- a/benchmark/compare_benchmarks.py
+++ b/benchmark/compare_benchmarks.py
@@ -49,7 +49,7 @@ BENCHMARK_PATTERN = re.compile(
     r"<(?P<impl>STL|Absl|BTree)"
     r"(?P<container>MultiMap|MultiSet|Map|Set)"
     r"<(?P<data_type>std::(?:int32_t|int64_t|string))"
-    r"(?:, (?P<node_size>\d+))?"
+    r"(?:, (?P<node_size>\d+|platanus::kAutoSize))?"
     r">>$"
 )
 
@@ -69,7 +69,10 @@ def parse_benchmark_name(name: str) -> dict[str, str] | None:
         parsed["label"] = "absl"
         return parsed
     if impl == "BTree" and node_size is not None:
-        parsed["label"] = f"platanus({node_size})"
+        if node_size == "platanus::kAutoSize":
+            parsed["label"] = "platanus(auto)"
+        else:
+            parsed["label"] = f"platanus({node_size})"
         return parsed
     return None
 
@@ -84,10 +87,12 @@ def implementation_sort_key(label: str) -> tuple[int, int]:
         return (0, 0)
     if label == "absl":
         return (1, 0)
+    if label == "platanus(auto)":
+        return (2, 0)
     match = re.fullmatch(r"platanus\((\d+)\)", label)
     if match is not None:
-        return (2, int(match.group(1)))
-    return (3, 0)
+        return (3, int(match.group(1)))
+    return (4, 0)
 
 
 IMPLEMENTATION_PALETTE = [

--- a/benchmark/compare_benchmarks.py
+++ b/benchmark/compare_benchmarks.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path
 
 import plotly.graph_objects as go
+from plotly.subplots import make_subplots
 
 
 def load_benchmarks(path: Path) -> tuple[dict[str, float], str]:
@@ -42,49 +44,191 @@ def build_order(left: dict[str, float], right: dict[str, float]) -> list[str]:
     return names
 
 
-def make_trace(names: list[str], values: dict[str, float], label: str, color: str) -> go.Bar:
-    y_values = [values.get(name) for name in names]
+BENCHMARK_PATTERN = re.compile(
+    r"^(?P<benchmark>BM_[^<]+)"
+    r"<(?P<impl>STL|BTree)"
+    r"(?P<container>MultiMap|MultiSet|Map|Set)"
+    r"<(?P<data_type>std::(?:int32_t|int64_t|string))"
+    r"(?:, (?P<node_size>\d+))?"
+    r">>$"
+)
+
+
+def parse_benchmark_name(name: str) -> dict[str, str] | None:
+    match = BENCHMARK_PATTERN.match(name)
+    if match is None:
+        return None
+
+    parsed = match.groupdict()
+    impl = parsed["impl"]
+    node_size = parsed["node_size"]
+    if impl == "STL":
+        parsed["label"] = "STL"
+        return parsed
+    if impl == "BTree" and node_size is not None:
+        parsed["label"] = f"platanus({node_size})"
+        return parsed
+    return None
+
+
+def subplot_title(benchmark: str, data_type: str, container: str) -> str:
+    benchmark_label = benchmark.removeprefix("BM_")
+    return f"{benchmark_label} / {data_type} / {container}"
+
+
+def implementation_sort_key(label: str) -> tuple[int, int]:
+    if label == "STL":
+        return (0, 0)
+    match = re.fullmatch(r"platanus\((\d+)\)", label)
+    if match is not None:
+        return (1, int(match.group(1)))
+    return (2, 0)
+
+
+IMPLEMENTATION_PALETTE = [
+    "#1f77b4",
+    "#ff7f0e",
+    "#2ca02c",
+    "#d62728",
+    "#9467bd",
+    "#8c564b",
+    "#e377c2",
+    "#7f7f7f",
+    "#bcbd22",
+    "#17becf",
+]
+
+
+def implementation_colors(labels: list[str]) -> list[str]:
+    color_map: dict[str, str] = {}
+    for index, label in enumerate(labels):
+        color_map[label] = IMPLEMENTATION_PALETTE[index % len(IMPLEMENTATION_PALETTE)]
+    return [color_map[label] for label in labels]
+
+
+def collect_subplot_groups(
+    left: dict[str, float], right: dict[str, float]
+) -> tuple[list[tuple[str, str]], list[str], dict[tuple[str, str], dict[str, dict[str, str]]]]:
+    row_order: list[tuple[str, str]] = []
+    row_seen: set[tuple[str, str]] = set()
+    container_order = ["Set", "MultiSet", "Map", "MultiMap"]
+    groups: dict[tuple[str, str], dict[str, dict[str, str]]] = {}
+
+    for name in build_order(left, right):
+        parsed = parse_benchmark_name(name)
+        if parsed is None:
+            continue
+
+        row_key = (parsed["benchmark"], parsed["data_type"])
+        container = parsed["container"]
+        label = parsed["label"]
+
+        if row_key not in row_seen:
+            row_seen.add(row_key)
+            row_order.append(row_key)
+
+        cell = groups.setdefault(row_key, {}).setdefault(container, {})
+        cell[label] = name
+
+    active_containers = [
+        container
+        for container in container_order
+        if any(container in row_groups for row_groups in groups.values())
+    ]
+    return row_order, active_containers, groups
+
+
+def make_trace(
+    x_values: list[str],
+    benchmark_names: list[str | None],
+    values: dict[str, float],
+    label: str,
+    color: str | list[str],
+) -> go.Bar:
+    y_values = [values.get(name) if name is not None else None for name in benchmark_names]
     hover_text = [
-        f"{name}<br>{label}: {value:.3f}" if value is not None else f"{name}<br>{label}: n/a"
-        for name, value in zip(names, y_values)
+        f"{name}<br>{label}: {value:.3f}" if name is not None and value is not None else f"{x_label}<br>{label}: n/a"
+        for x_label, name, value in zip(x_values, benchmark_names, y_values)
     ]
     return go.Bar(
         name=label,
-        x=names,
+        x=x_values,
         y=y_values,
-        marker_color=color,
+        marker=dict(color=color),
         hovertext=hover_text,
         hovertemplate="%{hovertext}<extra></extra>",
     )
 
 
 def create_figure(
-    left_name: str,
+    left_name: str | None,
     left_values: dict[str, float],
-    right_name: str,
+    right_name: str | None,
     right_values: dict[str, float],
     time_unit: str,
 ) -> go.Figure:
-    names = build_order(left_values, right_values)
+    row_order, active_containers, groups = collect_subplot_groups(left_values, right_values)
+    row_count = len(row_order)
+    col_count = len(active_containers)
 
-    figure = go.Figure(
-        data=[
-            make_trace(names, left_values, left_name, "#1f77b4"),
-            make_trace(names, right_values, right_name, "#ff7f0e"),
-        ]
+    if row_count == 0 or col_count == 0:
+        raise ValueError("No STL/BTree benchmark pairs found to plot.")
+
+    vertical_spacing = 0.04 if row_count <= 1 else min(0.04, 0.9 / (row_count - 1))
+
+    figure = make_subplots(
+        rows=row_count,
+        cols=col_count,
+        shared_xaxes=False,
+        subplot_titles=[
+            subplot_title(benchmark, data_type, container) if container in groups[row_key] else ""
+            for row_key in row_order
+            for benchmark, data_type in [row_key]
+            for container in active_containers
+        ],
+        vertical_spacing=vertical_spacing,
+        horizontal_spacing=0.05,
     )
+
+    traces_to_render = []
+    if left_name is not None:
+        traces_to_render.append((left_name, left_values, "#1f77b4"))
+    if right_name is not None:
+        traces_to_render.append((right_name, right_values, "#ff7f0e"))
+    single_series = len(traces_to_render) == 1
+
+    shown_legends: set[str] = set()
+    for row_index, row_key in enumerate(row_order, start=1):
+        row_groups = groups[row_key]
+        for col_index, container in enumerate(active_containers, start=1):
+            cell = row_groups.get(container)
+            if not cell:
+                continue
+
+            x_values = sorted(cell, key=implementation_sort_key)
+            benchmark_names = [cell.get(x_value) for x_value in x_values]
+            for trace_name, trace_values, trace_color in traces_to_render:
+                marker_color: str | list[str]
+                if single_series:
+                    marker_color = implementation_colors(x_values)
+                else:
+                    marker_color = trace_color
+                trace = make_trace(x_values, benchmark_names, trace_values, trace_name, marker_color)
+                trace.showlegend = trace_name not in shown_legends
+                shown_legends.add(trace_name)
+                figure.add_trace(trace, row=row_index, col=col_index)
+            figure.update_xaxes(title_text="Implementation", tickangle=0, row=row_index, col=col_index)
+            figure.update_yaxes(title_text=f"CPU Time ({time_unit})", row=row_index, col=col_index)
 
     figure.update_layout(
         title="Benchmark CPU Time Comparison",
         barmode="group",
         template="plotly_white",
-        xaxis_title="Benchmark",
-        yaxis_title=f"CPU Time ({time_unit})",
         legend_title="Source",
-        height=800,
-        margin=dict(l=80, r=40, t=80, b=220),
+        height=max(280 * row_count, 900),
+        width=max(360 * col_count, 1200),
+        margin=dict(l=80, r=40, t=100, b=160),
     )
-    figure.update_xaxes(tickangle=-35)
     return figure
 
 
@@ -95,13 +239,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "left",
         nargs="?",
-        required=True,
         help="First benchmark JSON file.",
     )
     parser.add_argument(
         "right",
         nargs="?",
-        required=True,
         help="Second benchmark JSON file.",
     )
     parser.add_argument(
@@ -115,24 +257,39 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    left_path = Path(args.left)
-    right_path = Path(args.right)
     output_path = Path(args.output)
+    if args.left is None and args.right is None:
+        raise ValueError("At least one of left or right benchmark JSON files must be provided.")
 
-    left_values, left_unit = load_benchmarks(left_path)
-    right_values, right_unit = load_benchmarks(right_path)
+    left_name: str | None = None
+    right_name: str | None = None
+    left_values: dict[str, float] = {}
+    right_values: dict[str, float] = {}
+    time_unit: str | None = None
 
-    if left_unit != right_unit:
-        raise ValueError(
-            f"Time units do not match: {left_path}={left_unit}, {right_path}={right_unit}"
-        )
+    if args.left is not None:
+        left_path = Path(args.left)
+        left_values, left_unit = load_benchmarks(left_path)
+        left_name = left_path.stem
+        time_unit = left_unit
+
+    if args.right is not None:
+        right_path = Path(args.right)
+        right_values, right_unit = load_benchmarks(right_path)
+        right_name = right_path.stem
+        if time_unit is None:
+            time_unit = right_unit
+        elif time_unit != right_unit:
+            raise ValueError(
+                f"Time units do not match: left={time_unit}, right={right_unit}"
+            )
 
     figure = create_figure(
-        left_path.stem,
+        left_name,
         left_values,
-        right_path.stem,
+        right_name,
         right_values,
-        left_unit,
+        time_unit if time_unit is not None else "unknown",
     )
     figure.write_html(output_path, include_plotlyjs=True)
     print(f"Wrote {output_path}")

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,12 @@
 # platanus
-`platanus` is a fork of the B-tree library [`cpp-btree`](https://code.google.com/archive/p/cpp-btree/).
+`platanus` is a modern fork of the B-tree library [`cpp-btree`](https://code.google.com/archive/p/cpp-btree/).
 
 
 ## Comparing to STL set/map
 A btree is both smaller and faster than STL set/map.
 The red-black tree implementation of STL set/map has an overhead of 3 pointers (left, right and parent) plus the node color information for each stored value.
 So a `std::set<std::int32_t>` consumes 32 bytes for each value stored.
-This btree implementation stores the fixed number of values on a nodes (usually 64) and doesn't store child
-pointers for leaf nodes.
+This btree implementation stores the fixed number of values on nodes (often around 64 when `MaxNumOfValues` is left at `platanus::kAutoSize`) and doesn't store child pointers for leaf nodes.
 The result is that a `platanus::btree_set<std::int32>` may use much less memory per stored value.
 For the random insertion benchmark, a `platanus::btree_set<std::int32_t>` with 64 values per node uses 4.64 bytes per stored value.
 
@@ -25,9 +24,9 @@ The packing of multiple values into nodes of a btree has another effect besides 
 
 
 ## Performance
-Generally speaking, `platunus` is slower than `cpp-btree` by approximately 13%.
+Generally speaking, `platanus` is slower than `cpp-btree` by approximately 13%.
 
-However, `platunus` is faster than `std::(multi)set` and `std::(multi)map` by approximately 59% (the values are median and the order of B-tree is 65 (default)).
+However, `platanus` is faster than `std::(multi)set` and `std::(multi)map` by approximately 59% in the author's benchmark environment.
 Forwarding an iterator of `platanus` is extremely faster than doing that of STL, while FIFO of `platanus` is slower than that of STL by approximately 19%.
 So, you should select an appropriate one matching your use case.
 
@@ -48,7 +47,7 @@ All functions and classes in this library are not thread-safe.
 
 
 ## Installation
-`platanus` is an header only library, so you don't have to install it.
+`platanus` is a header-only library, so you don't have to install it.
 When using CMake, you only have to link your program to `platanus::platanus`.
 For example, `target_link_libraries(your_program PUBLIC platanus::platanus)`.
 
@@ -74,7 +73,10 @@ cd build/release/benchmark
 The output has the following form.
 
 ```
-BM_<("STL" or "BTree")(container type)<(value type)[, (the max number of values per node)]>> (average time[ns] per iteration) (average CPU time[ns] per iteration) (the total of iterations)
+BM_<(implementation)(container type)<(value type)[, (the max number of values per node or platanus::kAutoSize)]>>
+  (average time[ns] per iteration)
+  (average CPU time[ns] per iteration)
+  (the total of iterations)
 ```
 
 When `PLATANUS_BENCHMARK_WITH_ABSL=ON` (default), benchmark registration switches to comparison mode and the benchmark set becomes:
@@ -108,7 +110,7 @@ The test cases are:
 | FwdIter | Benchmark iteration (forward) and reference through the container. Note that this benchmark includes a copy constructing of `key_type`. |
 | Merge | Benchmark merging two containers with the same size. |
 
-If you want to know a good size of values per node, run the following comamnd.
+If you want to know a good size of values per node, run the following command.
 
 ```
 cmake -S . -B build/release -DPLATANUS_BUILD_BENCHMARK=ON -DCMAKE_BUILD_TYPE=Release -DPLATANUS_BENCHMARK_VALUES_SIZE_TEST
@@ -123,7 +125,7 @@ For plotting benchmark JSON output, use:
 python3 benchmark/compare_benchmarks.py left.json right.json -o compared.html
 ```
 
-The plotting script understands `STL`, `absl`, and `platanus(N)` benchmark names and can also render a single JSON file.
+The plotting script understands `STL`, `absl`, `platanus(N)`, and `platanus(auto)` benchmark names and can also render a single JSON file.
 
 
 ## License

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,7 @@ If you want to check how much `platanus` is faster than STL, run the following c
 
 ```
 cmake -S . -B build/release -DPLATANUS_BUILD_BENCHMARK=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build/release --target btree_bench
 cd build/release/benchmark
 ./btree_bench
 ```
@@ -74,6 +75,27 @@ The output has the following form.
 
 ```
 BM_<("STL" or "BTree")(container type)<(value type)[, (the max number of values per node)]>> (average time[ns] per iteration) (average CPU time[ns] per iteration) (the total of iterations)
+```
+
+When `PLATANUS_BENCHMARK_WITH_ABSL=ON` (default), benchmark registration switches to comparison mode and the benchmark set becomes:
+
+| implementation | note |
+| --- | --- |
+| `STL` | `std::set`, `std::multiset`, `std::map`, `std::multimap` |
+| `Absl` | `absl::btree_set`, `absl::btree_multiset`, `absl::btree_map`, `absl::btree_multimap` |
+| `BTree(..., 64)` | `platanus` non-`pmr` containers with 64 values per node |
+
+In this comparison mode:
+
+- `BTree(..., 128)` is not registered.
+- `platanus::pmr` benchmark variants are not registered.
+- the intended comparison set is exactly `STL / absl / platanus(64)`.
+
+If you want the old wider benchmark set without `absl`, configure with:
+
+```
+cmake -S . -B build/release -DPLATANUS_BUILD_BENCHMARK=ON -DPLATANUS_BENCHMARK_WITH_ABSL=OFF -DCMAKE_BUILD_TYPE=Release
+cmake --build build/release --target btree_bench
 ```
 
 The test cases are:
@@ -90,9 +112,18 @@ If you want to know a good size of values per node, run the following comamnd.
 
 ```
 cmake -S . -B build/release -DPLATANUS_BUILD_BENCHMARK=ON -DCMAKE_BUILD_TYPE=Release -DPLATANUS_BENCHMARK_VALUES_SIZE_TEST
+cmake --build build/release --target btree_bench
 cd build/release/benchmark
 ./btree_bench
 ```
+
+For plotting benchmark JSON output, use:
+
+```bash
+python3 benchmark/compare_benchmarks.py left.json right.json -o compared.html
+```
+
+The plotting script understands `STL`, `absl`, and `platanus(N)` benchmark names and can also render a single JSON file.
 
 
 ## License

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,7 @@ The test cases are:
 If you want to know a good size of values per node, run the following comamnd.
 
 ```
-cmake -S . -B build/release -DPLATANUS_BUILD_BENCHMARK=ON -DCMAKE_BUILD_TYPE=Release -DPLATANUS_VALUES_SIZE_TEST
+cmake -S . -B build/release -DPLATANUS_BUILD_BENCHMARK=ON -DCMAKE_BUILD_TYPE=Release -DPLATANUS_BENCHMARK_VALUES_SIZE_TEST
 cd build/release/benchmark
 ./btree_bench
 ```

--- a/docs/reference/btree_map.md
+++ b/docs/reference/btree_map.md
@@ -8,7 +8,8 @@ template <
     typename Value,
     typename Compare           = std::ranges::less,
     typename Alloc             = std::allocator<std::pair<const Key, Value>>,
-    int MaxNumOfValues         = 64>
+    int MaxNumOfValues         = kAutoSize,
+    int NodeByteSize           = 256>
 class btree_map;
 }
 ```
@@ -22,7 +23,8 @@ class btree_map;
 | `Value` | Type of a value |
 | `Compare` | Type of a func obj comparing two key in a weak order. If Key doesn't implement three-way comparison operator, the default type does using `<` and `=`. |
 | `Alloc` | Type of an allocator. The default is `std::allocator<std::pair<const Key, Value>>`. |
-| `MaxNumOfValues` | The max number of values per node. The default is 64. |
+| `MaxNumOfValues` | The max number of values per node. The default is `platanus::kAutoSize`. |
+| `NodeByteSize` | Target node size in bytes used when computing the automatic number of values per node. The default is `256`. |
 
 
 ## Member types
@@ -336,7 +338,7 @@ Smaller values indicate space wastage.
 ### Swap
 ```cpp
 template <typename K, typename C, typename A, std::int_least16_t N>
-void swap(btree_map<K, C, A, N>& x, btree_map<K, C, A, N>& y);
+void swap(btree_map<K, V, C, A, N, B>& x, btree_map<K, V, C, A, N, B>& y);
 ```
 
 Swap `x` for `y` using `std::swap` to swap each member variable of `x` for that of `y`.

--- a/docs/reference/btree_multimap.md
+++ b/docs/reference/btree_multimap.md
@@ -8,7 +8,8 @@ template <
     typename Value,
     typename Compare           = std::ranges::less,
     typename Alloc             = std::allocator<std::pair<const Key, Value>>,
-    int MaxNumOfValues         = 64>
+    int MaxNumOfValues         = kAutoSize,
+    int NodeByteSize           = 256>
 class btree_multimap;
 }
 ```
@@ -22,7 +23,8 @@ class btree_multimap;
 | `Value` | Type of a value |
 | `Compare` | Type of a func obj comparing two key in a weak order. If Key doesn't implement three-way comparison operator, the default type does using `<` and `=`. |
 | `Alloc` | Type of an allocator. The default is `std::allocator<std::pair<const Key, Value>>`. |
-| `MaxNumOfValues` | The max number of values per node. The default is 64. |
+| `MaxNumOfValues` | The max number of values per node. The default is `platanus::kAutoSize`. |
+| `NodeByteSize` | Target node size in bytes used when computing the automatic number of values per node. The default is `256`. |
 
 
 ## Member types
@@ -326,7 +328,7 @@ Smaller values indicate space wastage.
 ### Swap
 ```cpp
 template <typename K, typename C, typename A, std::int_least16_t N>
-void swap(btree_multimap<K, C, A, N>& x, btree_multimap<K, C, A, N>& y);
+void swap(btree_multimap<K, V, C, A, N, B>& x, btree_multimap<K, V, C, A, N, B>& y);
 ```
 
 Swap `x` for `y` using `std::swap` to swap each member variable of `x` for that of `y`.

--- a/docs/reference/btree_multiset.md
+++ b/docs/reference/btree_multiset.md
@@ -7,7 +7,8 @@ template <
     typename Key,
     typename Compare           = std::ranges::less,
     typename Alloc             = std::allocator<Key>,
-    int MaxNumOfValues         = 64>
+    int MaxNumOfValues         = kAutoSize,
+    int NodeByteSize           = 256>
 class btree_multiset;
 }
 ```
@@ -20,7 +21,8 @@ class btree_multiset;
 | `Key` | Type of a key |
 | `Compare` | Type of a func obj comparing two key in a weak order. If Key doesn't implement three-way comparison operator, the default type does using `<` and `=`. |
 | `Alloc` | Type of an allocator. The default is `std::allocator<Key>`. |
-| `MaxNumOfValues` | The max number of values per node. The default is 64. |
+| `MaxNumOfValues` | The max number of values per node. The default is `platanus::kAutoSize`. |
+| `NodeByteSize` | Target node size in bytes used when computing the automatic number of values per node. The default is `256`. |
 
 
 ## Member types
@@ -322,7 +324,7 @@ Smaller values indicate space wastage.
 ### Swap
 ```cpp
 template <typename K, typename C, typename A, std::int_least16_t N>
-void swap(btree_multiset<K, C, A, N>& x, btree_multiset<K, C, A, N>& y);
+void swap(btree_multiset<K, C, A, N, B>& x, btree_multiset<K, C, A, N, B>& y);
 ```
 
 Swap `x` for `y` using `std::swap` to swap each member variable of `x` for that of `y`.

--- a/docs/reference/btree_set.md
+++ b/docs/reference/btree_set.md
@@ -7,7 +7,8 @@ template <
     typename Key,
     typename Compare           = std::ranges::less,
     typename Alloc             = std::allocator<Key>,
-    int MaxNumOfValues         = 64>
+    int MaxNumOfValues         = kAutoSize,
+    int NodeByteSize           = 256>
 class btree_set;
 }
 ```
@@ -20,7 +21,8 @@ class btree_set;
 | `Key` | Type of a key |
 | `Compare` | Type of a func obj comparing two key in a weak order. If Key doesn't implement three-way comparison operator, the default type does using `<` and `=`. |
 | `Alloc` | Type of an allocator. The default is `std::allocator<Key>`. |
-| `MaxNumOfValues` | The max number of values per node. The default is 64. |
+| `MaxNumOfValues` | The max number of values per node. The default is `platanus::kAutoSize`. |
+| `NodeByteSize` | Target node size in bytes used when computing the automatic number of values per node. The default is `256`. |
 
 
 ## Member types
@@ -322,7 +324,7 @@ Smaller values indicate space wastage.
 ### Swap
 ```cpp
 template <typename K, typename C, typename A, std::int_least16_t N>
-void swap(btree_set<K, C, A, N>& x, btree_set<K, C, A, N>& y);
+void swap(btree_set<K, C, A, N, B>& x, btree_set<K, C, A, N, B>& y);
 ```
 
 Swap `x` for `y` using `std::swap` to swap each member variable of `x` for that of `y`.

--- a/include/platanus/btree_map.hpp
+++ b/include/platanus/btree_map.hpp
@@ -38,6 +38,7 @@
 #include "internal/btree.hpp"
 #include "internal/btree_container.hpp"
 #include "pmr/polymorphic_allocator.hpp"
+#include "constants.hpp"
 
 namespace platanus {
 
@@ -46,270 +47,15 @@ template <
     typename Value,
     typename Compare   = std::ranges::less,
     typename Alloc     = std::allocator<std::pair<const Key, Value>>,
-    int MaxNumOfValues = 64>
+    int MaxNumOfValues = kAutoSize,
+    int NodeByteSize   = 256>
 class btree_map
     : public internal::btree_map_container<internal::btree<internal::btree_node_and_factory<
-          internal::btree_map_params<Key, Value, Compare, Alloc, MaxNumOfValues>>>> {
-  using self_type   = btree_map<Key, Value, Compare, Alloc, MaxNumOfValues>;
-  using params_type = internal::btree_map_params<Key, Value, Compare, Alloc, MaxNumOfValues>;
-  using btree_type  = internal::btree<internal::btree_node_and_factory<params_type>>;
-  using super_type  = internal::btree_map_container<btree_type>;
-
- public:
-  using key_type               = typename super_type::key_type;
-  using value_type             = typename super_type::value_type;
-  using mapped_type            = typename super_type::mapped_type;
-  using key_compare            = typename super_type::key_compare;
-  using allocator_type         = typename super_type::allocator_type;
-  using reference              = typename super_type::reference;
-  using const_reference        = typename super_type::const_reference;
-  using size_type              = typename super_type::size_type;
-  using difference_type        = typename super_type::difference_type;
-  using iterator               = typename super_type::iterator;
-  using const_iterator         = typename super_type::const_iterator;
-  using reverse_iterator       = typename super_type::reverse_iterator;
-  using const_reverse_iterator = typename super_type::const_reverse_iterator;
-
-  static constexpr std::size_t sizeof_leaf_node() { return super_type::sizeof_leaf_node(); }
-
-  static constexpr std::size_t sizeof_internal_node() { return super_type::sizeof_internal_node(); }
-
-  btree_map()                            = default;
-  btree_map(const self_type&)            = default;
-  btree_map(self_type&&)                 = default;
-  btree_map& operator=(const self_type&) = default;
-  btree_map& operator=(self_type&&)      = default;
-  ~btree_map()                           = default;
-
-  explicit btree_map(const key_compare& comp, const allocator_type& alloc = allocator_type())
-      : super_type(comp, alloc) {}
-
-  explicit btree_map(const allocator_type& alloc) : super_type(alloc) {}
-
-  // Range constructor.
-  template <class InputIterator>
-  btree_map(
-      InputIterator         b,
-      InputIterator         e,
-      const key_compare&    comp  = key_compare(),
-      const allocator_type& alloc = allocator_type()
-  )
-      : super_type(b, e, comp, alloc) {}
-  template <class InputIterator>
-  btree_map(InputIterator b, InputIterator e, const allocator_type& alloc)
-      : super_type(b, e, alloc) {}
-
-  explicit btree_map(const self_type& x, const allocator_type& alloc) : super_type(x, alloc) {}
-  explicit btree_map(self_type&& x, const allocator_type& alloc)
-      : super_type(std::move(x), alloc) {}
-
-  btree_map(
-      std::initializer_list<value_type> init,
-      const key_compare&                comp  = key_compare{},
-      const allocator_type&             alloc = allocator_type{}
-  )
-      : self_type{init.begin(), init.end(), comp, alloc} {}
-  btree_map(std::initializer_list<value_type> init, const allocator_type& alloc)
-      : self_type{init.begin(), init.end(), alloc} {}
-
-  using super_type::get_allocator;
-
-  using super_type::begin;
-  using super_type::cbegin;
-  using super_type::cend;
-  using super_type::crbegin;
-  using super_type::crend;
-  using super_type::end;
-  using super_type::rbegin;
-  using super_type::rend;
-
-  using super_type::empty;
-  using super_type::max_size;
-  using super_type::size;
-  using super_type::theoretical_max_size;
-
-  using super_type::clear;
-  using super_type::dump;
-  using super_type::swap;
-  using super_type::verify;
-
-  using super_type::average_bytes_per_value;
-  using super_type::bytes_used;
-  using super_type::fullness;
-  using super_type::height;
-  using super_type::internal_nodes;
-  using super_type::leaf_nodes;
-  using super_type::nodes;
-  using super_type::overhead;
-
-  using super_type::key_comp;
-
-  using super_type::equal_range;
-  using super_type::lower_bound;
-  using super_type::upper_bound;
-
-  using super_type::contains;
-  using super_type::count;
-  using super_type::find;
-
-  using super_type::erase;
-  using super_type::insert;
-
-  using super_type::merge;
-
-  using super_type::at;
-  using super_type::operator[];
-};
-
-template <typename K, typename V, typename C, typename A, int N>
-void swap(btree_map<K, V, C, A, N>& x, btree_map<K, V, C, A, N>& y) {
-  x.swap(y);
-}
-
-template <
-    typename Key,
-    typename Value,
-    typename Compare   = std::ranges::less,
-    typename Alloc     = std::allocator<std::pair<const Key, Value>>,
-    int MaxNumOfValues = 64>
-class btree_multimap
-    : public internal::btree_multi_container<internal::btree<internal::btree_node_and_factory<
-          internal::btree_map_params<Key, Value, Compare, Alloc, MaxNumOfValues>>>> {
-  using self_type   = btree_multimap<Key, Value, Compare, Alloc, MaxNumOfValues>;
-  using params_type = internal::btree_map_params<Key, Value, Compare, Alloc, MaxNumOfValues>;
-  using btree_type  = internal::btree<internal::btree_node_and_factory<params_type>>;
-  using super_type  = internal::btree_multi_container<btree_type>;
-
- public:
-  using mapped_type = typename btree_type::mapped_type;
-
-  using key_type               = typename super_type::key_type;
-  using value_type             = typename super_type::value_type;
-  using key_compare            = typename super_type::key_compare;
-  using allocator_type         = typename super_type::allocator_type;
-  using reference              = typename super_type::reference;
-  using const_reference        = typename super_type::const_reference;
-  using size_type              = typename super_type::size_type;
-  using difference_type        = typename super_type::difference_type;
-  using iterator               = typename super_type::iterator;
-  using const_iterator         = typename super_type::const_iterator;
-  using reverse_iterator       = typename super_type::reverse_iterator;
-  using const_reverse_iterator = typename super_type::const_reverse_iterator;
-
-  static constexpr std::size_t sizeof_leaf_node() { return super_type::sizeof_leaf_node(); }
-
-  static constexpr std::size_t sizeof_internal_node() { return super_type::sizeof_internal_node(); }
-
-  btree_multimap()                            = default;
-  btree_multimap(const self_type&)            = default;
-  btree_multimap(self_type&&)                 = default;
-  btree_multimap& operator=(const self_type&) = default;
-  btree_multimap& operator=(self_type&&)      = default;
-  ~btree_multimap()                           = default;
-
-  explicit btree_multimap(const key_compare& comp, const allocator_type& alloc = allocator_type())
-      : super_type(comp, alloc) {}
-
-  explicit btree_multimap(const allocator_type& alloc) : super_type(alloc) {}
-
-  // Range constructor.
-  template <class InputIterator>
-  btree_multimap(
-      InputIterator         b,
-      InputIterator         e,
-      const key_compare&    comp  = key_compare(),
-      const allocator_type& alloc = allocator_type()
-  )
-      : super_type(b, e, comp, alloc) {}
-
-  template <class InputIterator>
-  btree_multimap(InputIterator b, InputIterator e, const allocator_type& alloc)
-      : super_type(b, e, alloc) {}
-
-  explicit btree_multimap(const self_type& x, const allocator_type& alloc) : super_type(x, alloc) {}
-  explicit btree_multimap(self_type&& x, const allocator_type& alloc)
-      : super_type(std::move(x), alloc) {}
-
-  btree_multimap(
-      std::initializer_list<value_type> init,
-      const key_compare&                comp  = key_compare{},
-      const allocator_type&             alloc = allocator_type{}
-  )
-      : self_type{init.begin(), init.end(), comp, alloc} {}
-  btree_multimap(std::initializer_list<value_type> init, const allocator_type& alloc)
-      : self_type{init.begin(), init.end(), alloc} {}
-
-  using super_type::get_allocator;
-
-  using super_type::begin;
-  using super_type::cbegin;
-  using super_type::cend;
-  using super_type::crbegin;
-  using super_type::crend;
-  using super_type::end;
-  using super_type::rbegin;
-  using super_type::rend;
-
-  using super_type::empty;
-  using super_type::max_size;
-  using super_type::size;
-  using super_type::theoretical_max_size;
-
-  using super_type::clear;
-  using super_type::dump;
-  using super_type::swap;
-  using super_type::verify;
-
-  using super_type::average_bytes_per_value;
-  using super_type::bytes_used;
-  using super_type::fullness;
-  using super_type::height;
-  using super_type::internal_nodes;
-  using super_type::leaf_nodes;
-  using super_type::nodes;
-  using super_type::overhead;
-
-  using super_type::key_comp;
-
-  using super_type::equal_range;
-  using super_type::lower_bound;
-  using super_type::upper_bound;
-
-  using super_type::contains;
-  using super_type::count;
-  using super_type::find;
-
-  using super_type::erase;
-  using super_type::insert;
-
-  using super_type::merge;
-};
-
-template <typename K, typename V, typename C, typename A, int N>
-void swap(btree_multimap<K, V, C, A, N>& x, btree_multimap<K, V, C, A, N>& y) {
-  x.swap(y);
-}
-
-namespace pmr {
-
-template <
-    typename Key,
-    typename Value,
-    typename Compare   = std::ranges::less,
-    int MaxNumOfValues = 64>
-class btree_map : public internal::btree_map_container<
-                      internal::btree<internal::btree_node_and_factory<internal::btree_map_params<
-                          Key,
-                          Value,
-                          Compare,
-                          pmr::polymorphic_allocator<>,
-                          MaxNumOfValues>>>> {
-  using self_type = btree_map<Key, Value, Compare, MaxNumOfValues>;
+          internal::btree_map_params<Key, Value, Compare, Alloc, MaxNumOfValues, NodeByteSize>>>> {
+  using self_type = btree_map<Key, Value, Compare, Alloc, MaxNumOfValues, NodeByteSize>;
   using params_type =
-      internal::btree_map_params<Key, Value, Compare, pmr::polymorphic_allocator<>, MaxNumOfValues>;
-  using btree_type = internal::btree<internal::btree_node_and_factory<
-      internal::
-          btree_map_params<Key, Value, Compare, pmr::polymorphic_allocator<>, MaxNumOfValues>>>;
+      internal::btree_map_params<Key, Value, Compare, Alloc, MaxNumOfValues, NodeByteSize>;
+  using btree_type = internal::btree<internal::btree_node_and_factory<params_type>>;
   using super_type = internal::btree_map_container<btree_type>;
 
  public:
@@ -418,8 +164,8 @@ class btree_map : public internal::btree_map_container<
   using super_type::operator[];
 };
 
-template <typename K, typename V, typename C, int N>
-void swap(btree_map<K, V, C, N>& x, btree_map<K, V, C, N>& y) {
+template <typename K, typename V, typename C, typename A, int N, int B>
+void swap(btree_map<K, V, C, A, N, B>& x, btree_map<K, V, C, A, N, B>& y) {
   x.swap(y);
 }
 
@@ -427,21 +173,16 @@ template <
     typename Key,
     typename Value,
     typename Compare   = std::ranges::less,
-    int MaxNumOfValues = 64>
+    typename Alloc     = std::allocator<std::pair<const Key, Value>>,
+    int MaxNumOfValues = kAutoSize,
+    int NodeByteSize   = 256>
 class btree_multimap
-    : public internal::btree_multi_container<
-          internal::btree<internal::btree_node_and_factory<internal::btree_map_params<
-              Key,
-              Value,
-              Compare,
-              pmr::polymorphic_allocator<>,
-              MaxNumOfValues>>>> {
-  using self_type = btree_multimap<Key, Value, Compare, MaxNumOfValues>;
+    : public internal::btree_multi_container<internal::btree<internal::btree_node_and_factory<
+          internal::btree_map_params<Key, Value, Compare, Alloc, MaxNumOfValues, NodeByteSize>>>> {
+  using self_type = btree_multimap<Key, Value, Compare, Alloc, MaxNumOfValues, NodeByteSize>;
   using params_type =
-      internal::btree_map_params<Key, Value, Compare, pmr::polymorphic_allocator<>, MaxNumOfValues>;
-  using btree_type = internal::btree<internal::btree_node_and_factory<
-      internal::
-          btree_map_params<Key, Value, Compare, pmr::polymorphic_allocator<>, MaxNumOfValues>>>;
+      internal::btree_map_params<Key, Value, Compare, Alloc, MaxNumOfValues, NodeByteSize>;
+  using btree_type = internal::btree<internal::btree_node_and_factory<params_type>>;
   using super_type = internal::btree_multi_container<btree_type>;
 
  public:
@@ -549,8 +290,282 @@ class btree_multimap
   using super_type::merge;
 };
 
-template <typename K, typename V, typename C, int N>
-void swap(btree_multimap<K, V, C, N>& x, btree_multimap<K, V, C, N>& y) {
+template <typename K, typename V, typename C, typename A, int N, int B>
+void swap(btree_multimap<K, V, C, A, N, B>& x, btree_multimap<K, V, C, A, N, B>& y) {
+  x.swap(y);
+}
+
+namespace pmr {
+
+template <
+    typename Key,
+    typename Value,
+    typename Compare   = std::ranges::less,
+    int MaxNumOfValues = kAutoSize,
+    int NodeByteSize   = 256>
+class btree_map : public internal::btree_map_container<
+                      internal::btree<internal::btree_node_and_factory<internal::btree_map_params<
+                          Key,
+                          Value,
+                          Compare,
+                          pmr::polymorphic_allocator<>,
+                          MaxNumOfValues,
+                          NodeByteSize>>>> {
+  using self_type   = btree_map<Key, Value, Compare, MaxNumOfValues, NodeByteSize>;
+  using params_type = internal::btree_map_params<
+      Key,
+      Value,
+      Compare,
+      pmr::polymorphic_allocator<>,
+      MaxNumOfValues,
+      NodeByteSize>;
+  using btree_type = internal::btree<internal::btree_node_and_factory<params_type>>;
+  using super_type = internal::btree_map_container<btree_type>;
+
+ public:
+  using key_type               = typename super_type::key_type;
+  using value_type             = typename super_type::value_type;
+  using mapped_type            = typename super_type::mapped_type;
+  using key_compare            = typename super_type::key_compare;
+  using allocator_type         = typename super_type::allocator_type;
+  using reference              = typename super_type::reference;
+  using const_reference        = typename super_type::const_reference;
+  using size_type              = typename super_type::size_type;
+  using difference_type        = typename super_type::difference_type;
+  using iterator               = typename super_type::iterator;
+  using const_iterator         = typename super_type::const_iterator;
+  using reverse_iterator       = typename super_type::reverse_iterator;
+  using const_reverse_iterator = typename super_type::const_reverse_iterator;
+
+  static constexpr std::size_t sizeof_leaf_node() { return super_type::sizeof_leaf_node(); }
+
+  static constexpr std::size_t sizeof_internal_node() { return super_type::sizeof_internal_node(); }
+
+  btree_map()                            = default;
+  btree_map(const self_type&)            = default;
+  btree_map(self_type&&)                 = default;
+  btree_map& operator=(const self_type&) = default;
+  btree_map& operator=(self_type&&)      = default;
+  ~btree_map()                           = default;
+
+  explicit btree_map(const key_compare& comp, const allocator_type& alloc = allocator_type())
+      : super_type(comp, alloc) {}
+
+  explicit btree_map(const allocator_type& alloc) : super_type(alloc) {}
+
+  // Range constructor.
+  template <class InputIterator>
+  btree_map(
+      InputIterator         b,
+      InputIterator         e,
+      const key_compare&    comp  = key_compare(),
+      const allocator_type& alloc = allocator_type()
+  )
+      : super_type(b, e, comp, alloc) {}
+  template <class InputIterator>
+  btree_map(InputIterator b, InputIterator e, const allocator_type& alloc)
+      : super_type(b, e, alloc) {}
+
+  explicit btree_map(const self_type& x, const allocator_type& alloc) : super_type(x, alloc) {}
+  explicit btree_map(self_type&& x, const allocator_type& alloc)
+      : super_type(std::move(x), alloc) {}
+
+  btree_map(
+      std::initializer_list<value_type> init,
+      const key_compare&                comp  = key_compare{},
+      const allocator_type&             alloc = allocator_type{}
+  )
+      : self_type{init.begin(), init.end(), comp, alloc} {}
+  btree_map(std::initializer_list<value_type> init, const allocator_type& alloc)
+      : self_type{init.begin(), init.end(), alloc} {}
+
+  using super_type::get_allocator;
+
+  using super_type::begin;
+  using super_type::cbegin;
+  using super_type::cend;
+  using super_type::crbegin;
+  using super_type::crend;
+  using super_type::end;
+  using super_type::rbegin;
+  using super_type::rend;
+
+  using super_type::empty;
+  using super_type::max_size;
+  using super_type::size;
+  using super_type::theoretical_max_size;
+
+  using super_type::clear;
+  using super_type::dump;
+  using super_type::swap;
+  using super_type::verify;
+
+  using super_type::average_bytes_per_value;
+  using super_type::bytes_used;
+  using super_type::fullness;
+  using super_type::height;
+  using super_type::internal_nodes;
+  using super_type::leaf_nodes;
+  using super_type::nodes;
+  using super_type::overhead;
+
+  using super_type::key_comp;
+
+  using super_type::equal_range;
+  using super_type::lower_bound;
+  using super_type::upper_bound;
+
+  using super_type::contains;
+  using super_type::count;
+  using super_type::find;
+
+  using super_type::erase;
+  using super_type::insert;
+
+  using super_type::merge;
+
+  using super_type::at;
+  using super_type::operator[];
+};
+
+template <typename K, typename V, typename C, int N, int B>
+void swap(btree_map<K, V, C, N, B>& x, btree_map<K, V, C, N, B>& y) {
+  x.swap(y);
+}
+
+template <
+    typename Key,
+    typename Value,
+    typename Compare   = std::ranges::less,
+    int MaxNumOfValues = kAutoSize,
+    int NodeByteSize   = 256>
+class btree_multimap
+    : public internal::btree_multi_container<
+          internal::btree<internal::btree_node_and_factory<internal::btree_map_params<
+              Key,
+              Value,
+              Compare,
+              pmr::polymorphic_allocator<>,
+              MaxNumOfValues,
+              NodeByteSize>>>> {
+  using self_type   = btree_multimap<Key, Value, Compare, MaxNumOfValues, NodeByteSize>;
+  using params_type = internal::btree_map_params<
+      Key,
+      Value,
+      Compare,
+      pmr::polymorphic_allocator<>,
+      MaxNumOfValues,
+      NodeByteSize>;
+  using btree_type = internal::btree<internal::btree_node_and_factory<params_type>>;
+  using super_type = internal::btree_multi_container<btree_type>;
+
+ public:
+  using mapped_type = typename btree_type::mapped_type;
+
+  using key_type               = typename super_type::key_type;
+  using value_type             = typename super_type::value_type;
+  using key_compare            = typename super_type::key_compare;
+  using allocator_type         = typename super_type::allocator_type;
+  using reference              = typename super_type::reference;
+  using const_reference        = typename super_type::const_reference;
+  using size_type              = typename super_type::size_type;
+  using difference_type        = typename super_type::difference_type;
+  using iterator               = typename super_type::iterator;
+  using const_iterator         = typename super_type::const_iterator;
+  using reverse_iterator       = typename super_type::reverse_iterator;
+  using const_reverse_iterator = typename super_type::const_reverse_iterator;
+
+  static constexpr std::size_t sizeof_leaf_node() { return super_type::sizeof_leaf_node(); }
+
+  static constexpr std::size_t sizeof_internal_node() { return super_type::sizeof_internal_node(); }
+
+  btree_multimap()                            = default;
+  btree_multimap(const self_type&)            = default;
+  btree_multimap(self_type&&)                 = default;
+  btree_multimap& operator=(const self_type&) = default;
+  btree_multimap& operator=(self_type&&)      = default;
+  ~btree_multimap()                           = default;
+
+  explicit btree_multimap(const key_compare& comp, const allocator_type& alloc = allocator_type())
+      : super_type(comp, alloc) {}
+
+  explicit btree_multimap(const allocator_type& alloc) : super_type(alloc) {}
+
+  // Range constructor.
+  template <class InputIterator>
+  btree_multimap(
+      InputIterator         b,
+      InputIterator         e,
+      const key_compare&    comp  = key_compare(),
+      const allocator_type& alloc = allocator_type()
+  )
+      : super_type(b, e, comp, alloc) {}
+
+  template <class InputIterator>
+  btree_multimap(InputIterator b, InputIterator e, const allocator_type& alloc)
+      : super_type(b, e, alloc) {}
+
+  explicit btree_multimap(const self_type& x, const allocator_type& alloc) : super_type(x, alloc) {}
+  explicit btree_multimap(self_type&& x, const allocator_type& alloc)
+      : super_type(std::move(x), alloc) {}
+
+  btree_multimap(
+      std::initializer_list<value_type> init,
+      const key_compare&                comp  = key_compare{},
+      const allocator_type&             alloc = allocator_type{}
+  )
+      : self_type{init.begin(), init.end(), comp, alloc} {}
+  btree_multimap(std::initializer_list<value_type> init, const allocator_type& alloc)
+      : self_type{init.begin(), init.end(), alloc} {}
+
+  using super_type::get_allocator;
+
+  using super_type::begin;
+  using super_type::cbegin;
+  using super_type::cend;
+  using super_type::crbegin;
+  using super_type::crend;
+  using super_type::end;
+  using super_type::rbegin;
+  using super_type::rend;
+
+  using super_type::empty;
+  using super_type::max_size;
+  using super_type::size;
+  using super_type::theoretical_max_size;
+
+  using super_type::clear;
+  using super_type::dump;
+  using super_type::swap;
+  using super_type::verify;
+
+  using super_type::average_bytes_per_value;
+  using super_type::bytes_used;
+  using super_type::fullness;
+  using super_type::height;
+  using super_type::internal_nodes;
+  using super_type::leaf_nodes;
+  using super_type::nodes;
+  using super_type::overhead;
+
+  using super_type::key_comp;
+
+  using super_type::equal_range;
+  using super_type::lower_bound;
+  using super_type::upper_bound;
+
+  using super_type::contains;
+  using super_type::count;
+  using super_type::find;
+
+  using super_type::erase;
+  using super_type::insert;
+
+  using super_type::merge;
+};
+
+template <typename K, typename V, typename C, int N, int B>
+void swap(btree_multimap<K, V, C, N, B>& x, btree_multimap<K, V, C, N, B>& y) {
   x.swap(y);
 }
 }  // namespace pmr

--- a/include/platanus/btree_set.hpp
+++ b/include/platanus/btree_set.hpp
@@ -39,6 +39,7 @@
 #include "internal/btree.hpp"
 #include "internal/btree_container.hpp"
 #include "pmr/polymorphic_allocator.hpp"
+#include "constants.hpp"
 
 namespace platanus {
 
@@ -46,14 +47,14 @@ template <
     typename Key,
     typename Compare   = std::ranges::less,
     typename Alloc     = std::allocator<Key>,
-    int MaxNumOfValues = 64>
+    int MaxNumOfValues = kAutoSize,
+    int NodeByteSize   = 256>
 class btree_set
     : public internal::btree_unique_container<internal::btree<internal::btree_node_and_factory<
-          internal::btree_set_params<Key, Compare, Alloc, MaxNumOfValues>>>> {
-  using self_type   = btree_set<Key, Compare, Alloc, MaxNumOfValues>;
-  using params_type = internal::btree_set_params<Key, Compare, Alloc, MaxNumOfValues>;
-  using btree_type  = internal::btree<internal::btree_node_and_factory<
-       internal::btree_set_params<Key, Compare, Alloc, MaxNumOfValues>>>;
+          internal::btree_set_params<Key, Compare, Alloc, MaxNumOfValues, NodeByteSize>>>> {
+  using self_type   = btree_set<Key, Compare, Alloc, MaxNumOfValues, NodeByteSize>;
+  using params_type = internal::btree_set_params<Key, Compare, Alloc, MaxNumOfValues, NodeByteSize>;
+  using btree_type  = internal::btree<internal::btree_node_and_factory<params_type>>;
   using super_type  = internal::btree_unique_container<btree_type>;
 
  public:
@@ -159,8 +160,8 @@ class btree_set
   using super_type::merge;
 };
 
-template <typename K, typename C, typename A, int N>
-void swap(btree_set<K, C, A, N>& x, btree_set<K, C, A, N>& y) {
+template <typename K, typename C, typename A, int N, int B>
+void swap(btree_set<K, C, A, N, B>& x, btree_set<K, C, A, N, B>& y) {
   x.swap(y);
 }
 
@@ -168,14 +169,14 @@ template <
     typename Key,
     typename Compare   = std::ranges::less,
     typename Alloc     = std::allocator<Key>,
-    int MaxNumOfValues = 64>
+    int MaxNumOfValues = kAutoSize,
+    int NodeByteSize   = 256>
 class btree_multiset
     : public internal::btree_multi_container<internal::btree<internal::btree_node_and_factory<
-          internal::btree_set_params<Key, Compare, Alloc, MaxNumOfValues>>>> {
-  using self_type   = btree_multiset<Key, Compare, Alloc, MaxNumOfValues>;
-  using params_type = internal::btree_set_params<Key, Compare, Alloc, MaxNumOfValues>;
-  using btree_type  = internal::btree<internal::btree_node_and_factory<
-       internal::btree_set_params<Key, Compare, Alloc, MaxNumOfValues>>>;
+          internal::btree_set_params<Key, Compare, Alloc, MaxNumOfValues, NodeByteSize>>>> {
+  using self_type   = btree_multiset<Key, Compare, Alloc, MaxNumOfValues, NodeByteSize>;
+  using params_type = internal::btree_set_params<Key, Compare, Alloc, MaxNumOfValues, NodeByteSize>;
+  using btree_type  = internal::btree<internal::btree_node_and_factory<params_type>>;
   using super_type  = internal::btree_multi_container<btree_type>;
 
  public:
@@ -281,21 +282,28 @@ class btree_multiset
   using super_type::merge;
 };
 
-template <typename K, typename C, typename A, int N>
-void swap(btree_multiset<K, C, A, N>& x, btree_multiset<K, C, A, N>& y) {
+template <typename K, typename C, typename A, int N, int B>
+void swap(btree_multiset<K, C, A, N, B>& x, btree_multiset<K, C, A, N, B>& y) {
   x.swap(y);
 }
 
 namespace pmr {
 
-template <typename Key, typename Compare = std::ranges::less, int MaxNumOfValues = 64>
-class btree_set
-    : public internal::btree_unique_container<internal::btree<internal::btree_node_and_factory<
-          internal::
-              btree_set_params<Key, Compare, pmr::polymorphic_allocator<>, MaxNumOfValues>>>> {
-  using self_type = btree_set<Key, Compare, MaxNumOfValues>;
-  using params_type =
-      internal::btree_set_params<Key, Compare, pmr::polymorphic_allocator<>, MaxNumOfValues>;
+template <
+    typename Key,
+    typename Compare   = std::ranges::less,
+    int MaxNumOfValues = kAutoSize,
+    int NodeByteSize   = 256>
+class btree_set : public internal::btree_unique_container<
+                      internal::btree<internal::btree_node_and_factory<internal::btree_set_params<
+                          Key,
+                          Compare,
+                          pmr::polymorphic_allocator<>,
+                          MaxNumOfValues,
+                          NodeByteSize>>>> {
+  using self_type   = btree_set<Key, Compare, MaxNumOfValues, NodeByteSize>;
+  using params_type = internal::
+      btree_set_params<Key, Compare, pmr::polymorphic_allocator<>, MaxNumOfValues, NodeByteSize>;
   using btree_type = internal::btree<internal::btree_node_and_factory<params_type>>;
   using super_type = internal::btree_unique_container<btree_type>;
 
@@ -402,19 +410,27 @@ class btree_set
   using super_type::merge;
 };
 
-template <typename K, typename C, int N>
-void swap(btree_set<K, C, N>& x, btree_set<K, C, N>& y) {
+template <typename K, typename C, int N, int B>
+void swap(btree_set<K, C, N, B>& x, btree_set<K, C, N, B>& y) {
   x.swap(y);
 }
 
-template <typename Key, typename Compare = std::ranges::less, int MaxNumOfValues = 64>
+template <
+    typename Key,
+    typename Compare   = std::ranges::less,
+    int MaxNumOfValues = kAutoSize,
+    int NodeByteSize   = 256>
 class btree_multiset
-    : public internal::btree_multi_container<internal::btree<internal::btree_node_and_factory<
-          internal::
-              btree_set_params<Key, Compare, pmr::polymorphic_allocator<>, MaxNumOfValues>>>> {
-  using self_type = btree_multiset<Key, Compare, MaxNumOfValues>;
-  using params_type =
-      internal::btree_set_params<Key, Compare, pmr::polymorphic_allocator<>, MaxNumOfValues>;
+    : public internal::btree_multi_container<
+          internal::btree<internal::btree_node_and_factory<internal::btree_set_params<
+              Key,
+              Compare,
+              pmr::polymorphic_allocator<>,
+              MaxNumOfValues,
+              NodeByteSize>>>> {
+  using self_type   = btree_multiset<Key, Compare, MaxNumOfValues, NodeByteSize>;
+  using params_type = internal::
+      btree_set_params<Key, Compare, pmr::polymorphic_allocator<>, MaxNumOfValues, NodeByteSize>;
   using btree_type = internal::btree<internal::btree_node_and_factory<params_type>>;
   using super_type = internal::btree_multi_container<btree_type>;
 
@@ -521,8 +537,8 @@ class btree_multiset
   using super_type::merge;
 };
 
-template <typename K, typename C, int N>
-void swap(btree_multiset<K, C, N>& x, btree_multiset<K, C, N>& y) {
+template <typename K, typename C, int N, int B>
+void swap(btree_multiset<K, C, N, B>& x, btree_multiset<K, C, N, B>& y) {
   x.swap(y);
 }
 }  // namespace pmr

--- a/include/platanus/constants.hpp
+++ b/include/platanus/constants.hpp
@@ -1,0 +1,22 @@
+// Copyright 2024-2025 Yuya Asano <my_favorite_theory@yahoo.co.jp>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PLATANUS_CONSTANTS_H_
+#define PLATANUS_CONSTANTS_H_
+
+namespace platanus {
+inline static constexpr int kAutoSize = -1;
+}
+
+#endif

--- a/include/platanus/internal/btree_param.hpp
+++ b/include/platanus/internal/btree_param.hpp
@@ -35,10 +35,11 @@
 #include <utility>
 
 #include "btree_util.hpp"
+#include "../constants.hpp"
 
 namespace platanus::internal {
 
-template <typename Key, typename Compare, typename Alloc, int MaxNumOfValues>
+template <typename Key, typename Compare, typename Alloc, int MaxNumOfValues, int NodeByteSize>
 requires comp_requirement<Key, Compare>
 struct btree_common_params {
   using key_compare = Compare;
@@ -49,21 +50,39 @@ struct btree_common_params {
   using difference_type = std::ptrdiff_t;
 
   using count_type = int;
-
-  static constexpr count_type kMaxNumOfValues = MaxNumOfValues;
 };
 
 // A parameters structure for holding the type parameters for a btree_map.
-template <typename Key, typename Data, typename Compare, typename Alloc, int MaxNumOfValues>
-struct btree_map_params : public btree_common_params<Key, Compare, Alloc, MaxNumOfValues> {
+template <
+    typename Key,
+    typename Data,
+    typename Compare,
+    typename Alloc,
+    int MaxNumOfValues,
+    int NodeByteSize>
+struct btree_map_params
+    : public btree_common_params<Key, Compare, Alloc, MaxNumOfValues, NodeByteSize> {
+  using common_params      = btree_common_params<Key, Compare, Alloc, MaxNumOfValues, NodeByteSize>;
   using mapped_type        = Data;
   using value_type         = std::pair<const Key, mapped_type>;
   using mutable_value_type = std::pair<Key, mapped_type>;
 
-  using key_compare =
-      typename btree_common_params<Key, Compare, Alloc, MaxNumOfValues>::key_compare;
+  using key_compare = typename common_params::key_compare;
+
+  using count_type = typename common_params::count_type;
+
   using reference       = std::pair<const Key&, mapped_type&>;
   using const_reference = std::pair<const Key&, const mapped_type&>;
+
+  static constexpr count_type kMaxNumOfValues = []() {
+    if (MaxNumOfValues == ::platanus::kAutoSize) {
+      return static_cast<count_type>(
+          (NodeByteSize - 2 * sizeof(count_type) - 2 * sizeof(void*)) / sizeof(mutable_value_type)
+      );
+    } else {
+      return MaxNumOfValues;
+    }
+  }();
 
   static const Key& key(const value_type& x) noexcept { return x.first; }
   static const Key& key(const mutable_value_type& x) noexcept { return x.first; }
@@ -72,16 +91,30 @@ struct btree_map_params : public btree_common_params<Key, Compare, Alloc, MaxNum
 };
 
 // A parameters structure for holding the type parameters for a btree_set.
-template <typename Key, typename Compare, typename Alloc, int MaxNumOfValues>
-struct btree_set_params : public btree_common_params<Key, Compare, Alloc, MaxNumOfValues> {
+template <typename Key, typename Compare, typename Alloc, int MaxNumOfValues, int NodeByteSize>
+struct btree_set_params
+    : public btree_common_params<Key, Compare, Alloc, MaxNumOfValues, NodeByteSize> {
+  using common_params      = btree_common_params<Key, Compare, Alloc, MaxNumOfValues, NodeByteSize>;
   using mapped_type        = std::false_type;
   using value_type         = Key;
   using mutable_value_type = value_type;
 
-  using key_compare =
-      typename btree_common_params<Key, Compare, Alloc, MaxNumOfValues>::key_compare;
+  using key_compare = typename common_params::key_compare;
+
+  using count_type = typename common_params::count_type;
+
   using reference       = value_type&;
   using const_reference = const value_type&;
+
+  static constexpr count_type kMaxNumOfValues = []() {
+    if (MaxNumOfValues == ::platanus::kAutoSize) {
+      return static_cast<count_type>(
+          (NodeByteSize - 2 * sizeof(count_type) - 2 * sizeof(void*)) / sizeof(mutable_value_type)
+      );
+    } else {
+      return MaxNumOfValues;
+    }
+  }();
 
   static const Key& key(const value_type& x) noexcept { return x; }
 };

--- a/test/btree_pmr_test.cpp
+++ b/test/btree_pmr_test.cpp
@@ -32,34 +32,46 @@ BTREE_TEST(MultiSetTest, MultiSet)
 BTREE_TEST(MultiMapTest, MultiMap)
 
 TEST(node_factory, leaf_root_node) {
-  auto node_factory = internal::btree_node_factory<
-      internal::
-          btree_set_params<int, std::ranges::less, platanus::pmr::polymorphic_allocator<>, 3>>();
+  auto node_factory = internal::btree_node_factory<internal::btree_set_params<
+      int,
+      std::ranges::less,
+      platanus::pmr::polymorphic_allocator<>,
+      3,
+      256>>();
 
   auto root = node_factory.make_root_node(true);
 }
 
 TEST(node_factory, internal_root_node) {
-  auto node_factory = internal::btree_node_factory<
-      internal::
-          btree_set_params<int, std::ranges::less, platanus::pmr::polymorphic_allocator<>, 3>>();
+  auto node_factory = internal::btree_node_factory<internal::btree_set_params<
+      int,
+      std::ranges::less,
+      platanus::pmr::polymorphic_allocator<>,
+      3,
+      256>>();
 
   auto root = node_factory.make_root_node(false);
 }
 
 TEST(node_factory, leaf_node) {
-  auto node_factory = internal::btree_node_factory<
-      internal::
-          btree_set_params<int, std::ranges::less, platanus::pmr::polymorphic_allocator<>, 3>>();
+  auto node_factory = internal::btree_node_factory<internal::btree_set_params<
+      int,
+      std::ranges::less,
+      platanus::pmr::polymorphic_allocator<>,
+      3,
+      256>>();
 
   auto root = node_factory.make_root_node(false);
   root.get()->set_child(0, node_factory.make_node(true, root.get()));
 }
 
 TEST(node_factory, internal_node) {
-  auto node_factory = internal::btree_node_factory<
-      internal::
-          btree_set_params<int, std::ranges::less, platanus::pmr::polymorphic_allocator<>, 3>>();
+  auto node_factory = internal::btree_node_factory<internal::btree_set_params<
+      int,
+      std::ranges::less,
+      platanus::pmr::polymorphic_allocator<>,
+      3,
+      256>>();
 
   auto root = node_factory.make_root_node(false);
   root.get()->set_child(0, node_factory.make_node(false, root.get()));


### PR DESCRIPTION
Add an Abseil-backed benchmark configuration for ordered containers and
tighten the comparison target to a single platanus node-size when that
mode is enabled.

The benchmark build now supports a dedicated comparison mode controlled
by PLATANUS_BENCHMARK_WITH_ABSL.  When enabled, CMake fetches
abseil-cpp 20260107.1 as a benchmark-only dependency and builds
btree_bench against Abseil's btree containers.  In this mode the
registered implementations are intentionally restricted to:

  - STL
  - absl
  - platanus(64)

while platanus(128) and all pmr benchmark variants are excluded.

Update benchmark registration in btree_bench.cpp to add AbslSet,
AbslMultiSet, AbslMap, and AbslMultiMap coverage for Insert, Lookup,
Delete, FwdIter, and Merge across int32_t, int64_t, and string test
data.  Keep the previous wider registration behavior when the Abseil
comparison mode is disabled.

Teach benchmark/compare_benchmarks.py to recognize Absl* benchmark
names, place "absl" between STL and platanus on the x-axis, and accept
platanus::kAutoSize as "platanus(auto)".  Preserve single-file and
left/right comparison modes, and keep per-implementation coloring for
single-series plots.

Fix benchmark/compare_benchmark_stats.py argument parsing by removing
invalid positional required=True usage so the script works reliably in
its two-input comparison mode.

Refresh the benchmark and reference documentation to match the current
code:
  - document the Abseil comparison mode and its scope
  - document the benchmark build commands and plotting workflow
  - update reference signatures/defaults to reflect kAutoSize and
    NodeByteSize
  - fix stale wording and minor typos

This keeps the benchmark story aligned with the current implementation
and makes STL vs. absl vs. platanus(64) comparisons reproducible from a
fresh build tree.